### PR TITLE
Release v2.0

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,34 @@
+root = true
+
+[*]
+end_of_line = crlf
+insert_final_newline = true
+
+[*.{js,java}]
+indent_style = tab
+trim_trailing_whitespace = true
+
+[*.{xml,json}]
+indent_style = space
+indent_size = 2
+
+[plugin.xml]
+end_of_line = lf
+indent_size = 4
+
+[*.json]
+end_of_line = lf
+trim_trailing_whitespace = true
+
+[*.{h,m}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.ts]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Changelog for [skwas-cordova-plugin-datetimepicker](./README.md).
 
 - Validate and sanitize options
 
+### Breaking
+
+- Android: requires API level 26 (https://developer.android.com/distribute/best-practices/develop/target-sdk)
+
 ## 1.1.3
 
 - Android: Due to a [known bug](https://issuetracker.google.com/issues/36951008), when cancelling on Jelly Bean and KitKat, the cancel callback was not called. Instead the success callback was called. Fixes #18.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,56 +3,75 @@
 
 Changelog for [skwas-cordova-plugin-datetimepicker](./README.md).
 
-#### 1.1.3 ####
+## 2.0.0
+
+### New
+
+- Add support to hide the picker from code
+- Android: add support for `allowFutureDates`/`allowOldDates`
+
+### Fixes
+
+- Android/iOS: fix `minDate`/`maxDate` to support dates older than 1-1-1970
+
+### Improvements
+
+- Validate and sanitize options
+
+## 1.1.3
+
 - Android: Due to a [known bug](https://issuetracker.google.com/issues/36951008), when cancelling on Jelly Bean and KitKat, the cancel callback was not called. Instead the success callback was called. Fixes #18.
 
-#### 1.1.2 ####
+## 1.1.2
+
 - iOS: fix bug when `minDate` or `maxDate` was NSNull would cause exception.
 
-#### 1.1.1 ####
+## 1.1.1
+
 - iOS: fix null reference exception when `minDate` or  `maxDate` was not specified
 - iOS: fix `maxDate` not being set when `minDate` was not specified
 
-#### 1.1.0 ####
+## 1.1.0
+
 - Android/iOS: add support for min and max date settings
 - Add type information for Typescript support
 
-#### 1.0.0 ####
+## 1.0.0
 
 - Android/iOS: add support for cancel-event
 - Moved callback handlers from method parameters to options while keeping backward compatibility
 - Android: add 24 hour clock support
 
-#### 0.9.1 ####
+## 0.9.1
 
 - Android: add support for okText/cancelText
 
-#### 0.9.0 ####
+## 0.9.0
 
 - Android: fixed datetime mode only showing date picker (see #10)
 - Android: added theme support
 - Android: added calendar switch
 
-#### 0.8.0 ####
+## 0.8.0
 
 - Android: fix @NonNull error when building apk
 
-#### 0.7.0 ####
+## 0.7.0
 
 - iOS: use auto layout
 - iOS: remove < iOS 7 support (UIActionSheet)
 - iOS: remove custom modal picker type
 - Android: fix minute spinner for setting minute interval
 
-#### 0.6.0 ####
+## 0.6.0
 
 - Android: support Lollipop radial picker (no support for minute interval however)
 - Android: overall refactor and improvements
 
-#### 0.5.1 ####
+## 0.5.1
 
 - iOS: replace initWithWebView with pluginInitialize (deprecated in cordova-ios-4.0)
 
-#### 0.5.0 ####
+## 0.5.0
 
 - Rename repo to conform to npm/cordova plugin naming convention

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 [![npm version](https://badge.fury.io/js/skwas-cordova-plugin-datetimepicker.svg)](https://badge.fury.io/js/skwas-cordova-plugin-datetimepicker)
 
 # skwas-cordova-plugin-datetimepicker
+
 Cordova Plugin for showing a native date, time or datetime picker.
 
-## Installation ##
+## Installation
 
 `cordova plugin add skwas-cordova-plugin-datetimepicker`
 
@@ -11,14 +12,14 @@ or for latest
 
 `cordova plugin add https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker.git`
 
-## Supported platforms ##
+## Supported platforms
 
 - Android 4 and higher
 - iOS 8 and higher (tested with Xcode 7.2.3, Xcode 8 and Xcode 9.2)
 
-## Methods ##
+## Methods
 
-### show ###
+### show
 
 `show(options)`  
 Show the plugin with specified options.
@@ -29,7 +30,7 @@ Show the plugin with specified options and callbacks.
 This was the original way to call the plugin, and is kept for compatibility.
 > Note: The `successCallback` and `errorCallback` respectively will be ignored if the `success` or `error` callback is provided on the `options` argument.
 
-#### Options ####
+#### Options
 
 | Name                | Type                | Default        | Android                    | iOS                        | |
 |---------------------|---------------------|----------------|:--------------------------:|:--------------------------:|--------------------------|
@@ -53,57 +54,58 @@ This was the original way to call the plugin, and is kept for compatibility.
 | Name                | Type                | Default     | Description               |
 |---------------------|---------------------|-------------|---------------------------|
 | theme               | int                 | [Theme_DeviceDefault_Dialog](https://developer.android.com/reference/android/R.style.html#Theme_DeviceDefault_Dialog)| android.R.style theme |
-| calendar (obsolete) | boolean             | false       | `false` shows spinners, however this depend on the theme selected and SDK version. When `true`, forces a calendar view.|
+| calendar ([obsolete](./docs/Android_custom_theme_and_styling.md)) | boolean             | false       | `false` shows spinners, however this depend on the theme selected and SDK version. When `true`, forces a calendar view.|
 | is24HourView        | boolean             | true        | Use a 24 hour clock |
 
 > On Lollipop and upwards the date and time pickers changed to calendar and radial pickers. If you want to use spinners (for example to use `minuteInterval`), use a built-in [android.R.style](https://developer.android.com/reference/android/R.style.html) theme that shows a date and time picker with spinners or read up here [how to customize this](./docs/Android_custom_theme_and_styling.md).
 
-#### Example ####
+#### Example
 
 ```js
 document.addEventListener("deviceready", onDeviceReady, false);
 function onDeviceReady() {
 
-	var myDate = new Date(); // From model.
+    var myDate = new Date(); // From model.
 
-	cordova.plugins.DateTimePicker.show({
-		mode: "date",
-		date: myDate,
-		allowOldDates: true,
-		allowFutureDates: true,
-		minDate: new Date(),
-		maxDate: null,
-		minuteInterval: 15,
-		locale: "EN",
-		okText: "Select",
-		cancelText: "Cancel",
-		android: {
-			theme: 16974126, // Theme_DeviceDefault_Dialog
-			calendar: false,
-			is24HourView: true
-		},
-		success: function(newDate) {
-			// Handle new date.
-			console.info(newDate);
-			myDate = newDate;
-		},
-		cancel: function() {
-			console.info("Cancelled");
-		},
-		error: function (err) {
-			// Handle error.
-			console.error(err);
-		}
-	});
+    cordova.plugins.DateTimePicker.show({
+        mode: "date",
+        date: myDate,
+        allowOldDates: true,
+        allowFutureDates: true,
+        minDate: new Date(),
+        maxDate: null,
+        minuteInterval: 15,
+        locale: "EN",
+        okText: "Select",
+        cancelText: "Cancel",
+        android: {
+            theme: 16974126, // Theme_DeviceDefault_Dialog
+            calendar: false,
+            is24HourView: true
+        },
+        success: function(newDate) {
+            // Handle new date.
+            console.info(newDate);
+            myDate = newDate;
+        },
+        cancel: function() {
+            console.info("Cancelled");
+        },
+        error: function (err) {
+            // Handle error.
+            console.error(err);
+        }
+    });
 }
 ```
+
 > Note that not all options have to be set.
 
 ## Changelog
 
 For a list of all changes  [see here](./CHANGELOG.md).
 
-### Contributors ###
+### Contributors
 
 - [skwasjer](https://github.com/skwasjer)
 - [turshija](https://github.com/turshija)

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ or for latest
 
 ## Supported platforms
 
-- Android 4 and higher
-- iOS 8 and higher (tested with Xcode 7.2.3, Xcode 8 and Xcode 9.2)
+- Android 8 and higher
+- iOS 10 and higher
+- Cordova 7
 
 ## Methods
 
@@ -54,7 +55,6 @@ This was the original way to call the plugin, and is kept for compatibility.
 | Name                | Type                | Default     | Description               |
 |---------------------|---------------------|-------------|---------------------------|
 | theme               | int                 | [Theme_DeviceDefault_Dialog](https://developer.android.com/reference/android/R.style.html#Theme_DeviceDefault_Dialog)| android.R.style theme |
-| calendar ([obsolete](./docs/Android_custom_theme_and_styling.md)) | boolean             | false       | `false` shows spinners, however this depend on the theme selected and SDK version. When `true`, forces a calendar view.|
 | is24HourView        | boolean             | true        | Use a 24 hour clock |
 
 > On Lollipop and upwards the date and time pickers changed to calendar and radial pickers. If you want to use spinners (for example to use `minuteInterval`), use a built-in [android.R.style](https://developer.android.com/reference/android/R.style.html) theme that shows a date and time picker with spinners or read up here [how to customize this](./docs/Android_custom_theme_and_styling.md).

--- a/README.md
+++ b/README.md
@@ -98,7 +98,18 @@ function onDeviceReady() {
 }
 ```
 
-> Note that not all options have to be set.
+### hide
+
+`hide()`  
+Hide the date time picker.
+
+If the picker is currently being shown and a cancel-callback was provided in the options, the callback will be called when the picker is hidden.
+
+#### Example
+
+```js
+cordova.plugins.DateTimePicker.hide();
+```
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ This was the original way to call the plugin, and is kept for compatibility.
 |---------------------|---------------------|----------------|:--------------------------:|:--------------------------:|--------------------------|
 | mode                | String              | `date`         | `date`, `time`, `datetime` | `date`, `time`, `datetime` | The display mode |
 | date                | Date                |                | required                   | required                   | The initial date to display |
-| allowOldDates       | boolean             | true           | supported                  | supported                  | Allow older dates to be selected |
-| allowFutureDates    | boolean             | true           | supported                  | supported                  | Allow future dates to be selected |
-| minDate             | Date                |                | supported                  | supported                  | Set the minimum date that can be selected |
-| maxDate             | Date                |                | supported                  | supported                  | Set the maximum date that can be selected |
-| minuteInterval      | int                 | 1              | >= Honeycomb               | supported                  | For minute spinner the number of minutes per step |
-| locale              | String              | "EN"           | -                          | supported                  | The locale to use for text and date/time |
-| okText              | String              | "Select"       | supported                  | supported                  | The text to use for the ok button |
-| cancelText          | String              | "Cancel"       | supported                  | supported                  | The text to use for the cancel button |
-| success             | Function            | -              | supported                  | supported                  | The success callback |
-| cancel              | Function            | -              | supported                  | supported                  | The cancel callback |
-| error               | Function            | -              | supported                  | supported                  | The error callback |
+| allowOldDates       | boolean             | true           | ![Supported][supported]    | ![Supported][supported]    | Allow older dates to be selected |
+| allowFutureDates    | boolean             | true           | ![Supported][supported]    | ![Supported][supported]    | Allow future dates to be selected |
+| minDate             | Date                |                | ![Supported][supported]    | ![Supported][supported]    | Set the minimum date that can be selected |
+| maxDate             | Date                |                | ![Supported][supported]    | ![Supported][supported]    | Set the maximum date that can be selected |
+| minuteInterval      | int                 | 1              | >= Honeycomb               | ![Supported][supported]    | For minute spinner the number of minutes per step |
+| locale              | String              | "EN"           | -                          | ![Supported][supported]    | The locale to use for text and date/time |
+| okText              | String              | "Select"       | ![Supported][supported]    | ![Supported][supported]    | The text to use for the ok button |
+| cancelText          | String              | "Cancel"       | ![Supported][supported]    | ![Supported][supported]    | The text to use for the cancel button |
+| success             | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The success callback |
+| cancel              | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The cancel callback |
+| error               | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The error callback |
 | android             | Object              | {}             | optional                   | ignored                    | Android specific options |
 
 #### Android options
@@ -111,3 +111,7 @@ For a list of all changes  [see here](./CHANGELOG.md).
 - [turshija](https://github.com/turshija)
 - [emanfu](https://github.com/emanfu)
 - [masimplo](https://github.com/masimplo)
+
+
+[supported]: ./docs/res/check.svg "Supported"
+[not-supported]: ./doc/res/close.svg "Not supported"

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ function onDeviceReady() {
         cancelText: "Cancel",
         android: {
             theme: 16974126, // Theme_DeviceDefault_Dialog
-            calendar: false,
             is24HourView: true
         },
         success: function(newDate) {

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ This was the original way to call the plugin, and is kept for compatibility.
 |---------------------|---------------------|----------------|:--------------------------:|:--------------------------:|--------------------------|
 | mode                | String              | `date`         | `date`, `time`, `datetime` | `date`, `time`, `datetime` | The display mode |
 | date                | Date                |                | required                   | required                   | The initial date to display |
-| allowOldDates       | boolean             | true           | -                          | supported                  | Allow older dates to be selected |
-| allowFutureDates    | boolean             | true           | -                          | supported                  | Allow future dates to be selected |
+| allowOldDates       | boolean             | true           | supported                  | supported                  | Allow older dates to be selected |
+| allowFutureDates    | boolean             | true           | supported                  | supported                  | Allow future dates to be selected |
 | minDate             | Date                |                | supported                  | supported                  | Set the minimum date that can be selected |
 | maxDate             | Date                |                | supported                  | supported                  | Set the maximum date that can be selected |
 | minuteInterval      | int                 | 1              | >= Honeycomb               | supported                  | For minute spinner the number of minutes per step |

--- a/docs/Android_custom_theme_and_styling.md
+++ b/docs/Android_custom_theme_and_styling.md
@@ -41,6 +41,7 @@ So let's do it the proper way!
   ```
 
 In this example theme:
+
 - we defined a theme named `MyAppTheme` which we will apply to the Android activity later on.
 - we defined two custom styles for the date and time picker widget, with an attribute `datePickerMode` and `timePickerMode` both set to `spinner`. This should change the pickers from radials into spinners.
 
@@ -48,10 +49,13 @@ In this example theme:
 
 - Open the `config.xml` in the Cordova project root.
 - Add the Android schema with a namespace declaration to the `widget` element if it isn't already there:
+
   ```xml
   <widget ... xmlns:android="http://schemas.android.com/apk/res/android">
   ```
+
 - Add the following XML to the `widget` element:
+
   ```xml
   <widget ...>
     ...
@@ -67,7 +71,7 @@ In this example theme:
 
 Let's break down what is happening:
 
-#### Platform specific configuration
+### Platform specific configuration
 
 The `platform` element allows us configure the Android platform specifically, as this does not apply to `iOS` or others.
 
@@ -76,7 +80,7 @@ The `platform` element allows us configure the Android platform specifically, as
 </platform>
 ```
 
-#### Copy the styles file
+### Copy the styles file
 
 With the `resource-file` element we can copy a file to a target folder during build.
 
@@ -85,10 +89,10 @@ With the `resource-file` element we can copy a file to a target folder during bu
 ```
 
 > The base location of `src` is the project root, whereas the `target` location points to the location under the platform folder (`platforms/android`).
-
+>
 > NOTE: The `target` location may differ for other Cordova versions.
 
-#### Transform AndroidManifest.xml
+### Transform AndroidManifest.xml
 
 To enable our custom theme, we replace the default theme with our own on the `activity` element:
 
@@ -116,6 +120,7 @@ cordova.plugins.DateTimePicker.show({
   }
 })
 ```
+
 ## Build and run
 
 - `cordova build android`
@@ -152,4 +157,4 @@ And the result:
 
 With some extra configuration it is fairly easy to get spinners back in a reliable way and with proper theming.
 
-While in this example I solely focus on changing the picker mode style, there are more styling options available, but I will leave that as an exercise to the reader. 
+While in this example I solely focus on changing the picker mode style, there are more styling options available, but I will leave that as an exercise to the reader.

--- a/docs/res/check.svg
+++ b/docs/res/check.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<svg xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	id="Layer_1" version="1.1" viewBox="0 0 612 792" width="22" height="22">
+<style type="text/css">
+	.st0{fill:#41AD49;}
+</style>
+	<g>
+		<path class="st0" d="M562,396c0-141.4-114.6-256-256-256S50,254.6,50,396s114.6,256,256,256S562,537.4,562,396L562,396z    M501.7,296.3l-241,241l0,0l-17.2,17.2L110.3,421.3l58.8-58.8l74.5,74.5l199.4-199.4L501.7,296.3L501.7,296.3z" />
+	</g>
+</svg>

--- a/docs/res/close.svg
+++ b/docs/res/close.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<svg xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	id="Layer_1" version="1.1" viewBox="0 0 612 792" width="22" height="22">
+<style type="text/css">
+	.st0{fill:#cc0000;}
+</style>
+	<g>
+		<path class="st0" d="M562,396c0-141.4-114.6-256-256-256S50,254.6,50,396s114.6,256,256,256S562,537.4,562,396L562,396z M356.8,396 L475,514.2L424.2,565L306,446.8L187.8,565L137,514.2L255.2,396L137,277.8l50.8-50.8L306,345.2L424.2,227l50.8,50.8L356.8,396 L356.8,396z"/>
+	</g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.3",
+  "version": "2.0.0-alpha1",
   "name": "skwas-cordova-plugin-datetimepicker",
   "cordova_name": "DateTime picker",
   "description": "Cordova DateTime picker plugin",

--- a/package.json
+++ b/package.json
@@ -1,30 +1,30 @@
 {
-    "version": "1.1.3",
-    "name": "skwas-cordova-plugin-datetimepicker",
-    "cordova_name": "DateTime picker",
-    "description": "Cordova DateTime picker plugin",
-    "types": "./types/index.d.ts",
-    "repository": {
-        "type" : "git",
-        "url" : "https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker.git"
-    },
-    "keywords": [
-        "ecosystem:cordova",
-        "cordova-android",
-        "cordova-ios",
-        "cordova",
-        "datetime"
-    ],
-    "platforms": [
-        "android",
-        "ios"
-    ],
-    "engines": [],
-    "license": "MIT",
-    "author": "skwasjer",
-    "contributors": [
-        "turshija",
-        "emanfu",
-        "masimplo"
-    ]
+  "version": "1.1.3",
+  "name": "skwas-cordova-plugin-datetimepicker",
+  "cordova_name": "DateTime picker",
+  "description": "Cordova DateTime picker plugin",
+  "types": "./types/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker.git"
+  },
+  "keywords": [
+    "ecosystem:cordova",
+    "cordova-android",
+    "cordova-ios",
+    "cordova",
+    "datetime"
+  ],
+  "platforms": [
+    "android",
+    "ios"
+  ],
+  "engines": [],
+  "license": "MIT",
+  "author": "skwasjer",
+  "contributors": [
+    "turshija",
+    "emanfu",
+    "masimplo"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-alpha1",
+  "version": "2.0.0",
   "name": "skwas-cordova-plugin-datetimepicker",
   "cordova_name": "DateTime picker",
   "description": "Cordova DateTime picker plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="skwas-cordova-plugin-datetimepicker"
-    version="1.1.3">
+    version="2.0.0-alpha1">
     <name>DateTime picker</name>
     <description>Cordova DateTime picker plugin</description>
     <license>MIT</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="skwas-cordova-plugin-datetimepicker"
-    version="2.0.0-alpha1">
+    version="2.0.0">
     <name>DateTime picker</name>
     <description>Cordova DateTime picker plugin</description>
     <license>MIT</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -37,6 +37,7 @@ THE SOFTWARE.
     <js-module src="www/datetimepicker.js" name="DateTimePicker">
         <clobbers target="cordova.plugins.DateTimePicker" />
     </js-module>
+    <js-module src="www/utils.js" name="utils" />
 
     <!-- android -->
     <platform name="android">

--- a/src/android/DateTimePicker.java
+++ b/src/android/DateTimePicker.java
@@ -32,11 +32,14 @@ public class DateTimePicker extends CordovaPlugin {
 	 * Note that not all options are supported, they are here to match the options across all platforms.
 	 */
 	private class DateTimePickerOptions {
+		private static final long DATE_OBJ_MAX = 8640000000000000L;
+		private static final long DATE_OBJ_MIN = -DATE_OBJ_MAX;
+
 		@NonNull
 		public String mode = MODE_DATE;
 		public Date date = new Date();
-		public long minDate = 0;
-		public long maxDate = 0;
+		public Date minDate;
+		public Date maxDate;
 		public boolean allowOldDates = true;
 		public boolean allowFutureDates = true;
 		public int minuteInterval = 1;
@@ -55,15 +58,22 @@ public class DateTimePicker extends CordovaPlugin {
 		public DateTimePickerOptions(JSONObject obj) throws JSONException {
 			this();
 
+			long nowTicks = date.getTime();
+
 			mode = obj.optString("mode", mode);
 
 			date = new Date(obj.getLong("ticks"));
-			minDate = obj.optLong("minDate", minDate);
-			maxDate = obj.optLong("maxDate", maxDate);
-			minuteInterval = obj.optInt("minuteInterval", minuteInterval);
 
 			allowOldDates = obj.optBoolean("allowOldDates", allowOldDates);
 			allowFutureDates = obj.optBoolean("allowFutureDates", allowFutureDates);
+
+			minDate = new Date(obj.optLong("minDateTicks", allowOldDates ? DATE_OBJ_MIN : nowTicks));
+			maxDate = new Date(obj.optLong("maxDateTicks", allowFutureDates ? DATE_OBJ_MAX : nowTicks));
+			if (minDate.compareTo(maxDate) > 0) {
+				minDate = new Date(DATE_OBJ_MIN);
+			}
+
+			minuteInterval = obj.optInt("minuteInterval", minuteInterval);
 
 			if (!obj.isNull("okText")) {
 				okText = obj.optString("okText");
@@ -226,12 +236,9 @@ public class DateTimePicker extends CordovaPlugin {
 				dateDialog.setCalendarEnabled(options.calendar);
 
 				DatePicker dp = dateDialog.getDatePicker();
-				if (options.minDate > 0) {
-					dp.setMinDate(options.minDate);
-				}
-				if (options.maxDate > 0 && options.maxDate > options.minDate) {
-					dp.setMaxDate(options.maxDate);
-				}
+
+				dp.setMinDate(options.minDate.getTime());
+				dp.setMaxDate(options.maxDate.getTime());
 
 				showDialog(dateDialog, callbackContext);
 			}

--- a/src/android/DateTimePicker.java
+++ b/src/android/DateTimePicker.java
@@ -102,7 +102,7 @@ public class DateTimePicker extends CordovaPlugin {
 	}
 
 	@Override
-	public synchronized boolean execute(String action, JSONArray args, final CallbackContext callbackContext) throws JSONException {
+	public synchronized boolean execute(String action, JSONArray args, final CallbackContext callbackContext) {
 		Log.d(TAG, "DateTimePicker called with options: " + args);
 
 		switch (action) {

--- a/src/android/DateTimePicker.java
+++ b/src/android/DateTimePicker.java
@@ -114,16 +114,17 @@ public class DateTimePicker extends CordovaPlugin {
 	public synchronized boolean execute(String action, JSONArray args, final CallbackContext callbackContext) {
 		Log.d(TAG, "DateTimePicker called with options: " + args);
 
-		switch (action) {
-			case "show":
-				show(args, callbackContext);
-				return true;
-			case "hide":
-				hide(args, callbackContext);
-				return true;
-			default:
-				return false;
+		if (action.equals("show")) {
+			show(args, callbackContext);
+			return true;
 		}
+
+		if (action.equals("hide")) {
+			hide(args, callbackContext);
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/android/DateTimePicker.java
+++ b/src/android/DateTimePicker.java
@@ -29,7 +29,6 @@ public class DateTimePicker extends CordovaPlugin {
 
 	/**
 	 * Options for date picker.
-	 *
 	 * Note that not all options are supported, they are here to match the options across all platforms.
 	 */
 	private class DateTimePickerOptions {
@@ -120,7 +119,7 @@ public class DateTimePicker extends CordovaPlugin {
 	/**
 	 * Plugin 'show' method.
 	 *
-	 * @param data The JSON arguments passed to the method.
+	 * @param data            The JSON arguments passed to the method.
 	 * @param callbackContext The callback context.
 	 * @return true when the dialog is shown
 	 */
@@ -171,7 +170,7 @@ public class DateTimePicker extends CordovaPlugin {
 	/**
 	 * Plugin 'hide' method.
 	 *
-	 * @param data The JSON arguments passed to the method.
+	 * @param data            The JSON arguments passed to the method.
 	 * @param callbackContext The callback context.
 	 * @return always returns true.
 	 */
@@ -242,7 +241,7 @@ public class DateTimePicker extends CordovaPlugin {
 	/**
 	 * Show the picker dialog.
 	 *
-	 * @param dialog The dialog to show.
+	 * @param dialog          The dialog to show.
 	 * @param callbackContext The callback context.
 	 */
 	private synchronized void showDialog(final AlertDialog dialog, final CallbackContext callbackContext) {
@@ -258,8 +257,7 @@ public class DateTimePicker extends CordovaPlugin {
 					callbackContext.success(result);
 				} catch (JSONException ex) {
 					callbackContext.error("Failed to cancel.");
-				}
-				finally {
+				} finally {
 					_runnable = null;
 				}
 			}
@@ -272,7 +270,7 @@ public class DateTimePicker extends CordovaPlugin {
 	/**
 	 * Success callback for when a new date or time is set.
 	 *
-	 * @param calendar The calendar with the new date and/or time.
+	 * @param calendar        The calendar with the new date and/or time.
 	 * @param callbackContext The callback context.
 	 */
 	private synchronized void onCalendarSet(Calendar calendar, CallbackContext callbackContext) {
@@ -286,8 +284,7 @@ public class DateTimePicker extends CordovaPlugin {
 			callbackContext.success(result);
 		} catch (JSONException ex) {
 			callbackContext.error("Failed to serialize date. " + calendar.getTime().toString());
-		}
-		finally {
+		} finally {
 			_runnable = null;
 		}
 	}
@@ -315,7 +312,7 @@ public class DateTimePicker extends CordovaPlugin {
 			mCalendar.set(Calendar.DAY_OF_MONTH, dayOfMonth);
 
 			if (MODE_DATETIME.equalsIgnoreCase(mOptions.mode)) {
-				synchronized(mDatePickerPlugin) {
+				synchronized (mDatePickerPlugin) {
 					_activity.runOnUiThread(
 							_runnable = showTimeDialog(mDatePickerPlugin, mCallbackContext, mOptions, mCalendar)
 					);

--- a/src/android/DateTimePicker.java
+++ b/src/android/DateTimePicker.java
@@ -32,9 +32,6 @@ public class DateTimePicker extends CordovaPlugin {
 	 * Note that not all options are supported, they are here to match the options across all platforms.
 	 */
 	private class DateTimePickerOptions {
-		private static final long DATE_OBJ_MAX = 8640000000000000L;
-		private static final long DATE_OBJ_MIN = -DATE_OBJ_MAX;
-
 		@NonNull
 		public String mode = MODE_DATE;
 		public Date date = new Date();
@@ -67,10 +64,16 @@ public class DateTimePicker extends CordovaPlugin {
 			allowOldDates = obj.optBoolean("allowOldDates", allowOldDates);
 			allowFutureDates = obj.optBoolean("allowFutureDates", allowFutureDates);
 
-			minDate = new Date(obj.optLong("minDateTicks", allowOldDates ? DATE_OBJ_MIN : nowTicks));
-			maxDate = new Date(obj.optLong("maxDateTicks", allowFutureDates ? DATE_OBJ_MAX : nowTicks));
-			if (minDate.compareTo(maxDate) > 0) {
-				minDate = new Date(DATE_OBJ_MIN);
+			if (obj.has("minDateTicks")) {
+				minDate = new Date(obj.getLong("minDateTicks"));
+			} else if (!allowOldDates) {
+				minDate = new Date(nowTicks);
+			}
+
+			if (obj.has("maxDateTicks")) {
+				maxDate = new Date(obj.getLong("maxDateTicks"));
+			} else if (!allowFutureDates) {
+				maxDate = new Date(nowTicks);
 			}
 
 			minuteInterval = obj.optInt("minuteInterval", minuteInterval);
@@ -237,9 +240,12 @@ public class DateTimePicker extends CordovaPlugin {
 				dateDialog.setCalendarEnabled(options.calendar);
 
 				DatePicker dp = dateDialog.getDatePicker();
-
-				dp.setMinDate(options.minDate.getTime());
-				dp.setMaxDate(options.maxDate.getTime());
+				if (options.minDate != null) {
+					dp.setMinDate(options.minDate.getTime());
+				}
+				if (options.maxDate != null) {
+					dp.setMaxDate(options.maxDate.getTime());
+				}
 
 				showDialog(dateDialog, callbackContext);
 			}

--- a/src/android/TimePickerDialog.java
+++ b/src/android/TimePickerDialog.java
@@ -79,10 +79,10 @@ public class TimePickerDialog extends android.app.TimePickerDialog {
 		try {
 			Class<?> rClass = Class.forName("com.android.internal.R$id");
 			Field timePicker = rClass.getField("timePicker");
-			mTimePicker = (TimePicker)findViewById(timePicker.getInt(null));
+			mTimePicker = (TimePicker) findViewById(timePicker.getInt(null));
 			Field m = rClass.getField("minute");
 
-			NumberPicker mMinuteSpinner = (NumberPicker)mTimePicker.findViewById(m.getInt(null));
+			NumberPicker mMinuteSpinner = (NumberPicker) mTimePicker.findViewById(m.getInt(null));
 			if (mMinuteSpinner == null) {
 				mTimePicker = null;
 				mIsSupported = false;
@@ -101,7 +101,7 @@ public class TimePickerDialog extends android.app.TimePickerDialog {
 				displayedValues.add(String.format("%02d", i));
 			}
 
-			setDisplayedValues.invoke(mMinuteSpinner, (Object)displayedValues.toArray(new String[0]));
+			setDisplayedValues.invoke(mMinuteSpinner, (Object) displayedValues.toArray(new String[0]));
 			updateTime(mHourOfDay, mIsSupported ? mMinute / mIncrement : mMinute);
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/src/ios/DateTimePicker.h
+++ b/src/ios/DateTimePicker.h
@@ -14,6 +14,8 @@
 @property (strong) ModalPickerViewController* modalPicker;
 
 - (void)show:(CDVInvokedUrlCommand*)command;
-    
+
+- (void)hide:(CDVInvokedUrlCommand*)command;
+
 @end
 

--- a/src/ios/DateTimePicker.h
+++ b/src/ios/DateTimePicker.h
@@ -2,10 +2,11 @@
 #import <Cordova/CDVPlugin.h>
 #import "ModalPickerViewController.h"
 
-#ifndef k_DATEPICKER_DATETIME_FORMAT
-#define k_DATEPICKER_DATETIME_FORMAT @"yyyy-MM-dd'T'HH:mm:ss'Z'"
-#endif
-
+enum DTPDateBounds {
+    DDBMinDate = -8640000000000000,
+    DDBMaxDate = 8640000000000000,
+    DDBIntervalFactor = 1000
+};
 
 @interface DateTimePicker : CDVPlugin <UIViewControllerTransitioningDelegate> {
    

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -140,13 +140,14 @@
 {
     NSString *mode = [optionsOrNil objectForKey:@"mode"];
     long long ticks = [[optionsOrNil objectForKey:@"ticks"] longLongValue];
-    NSNumber *minDate = [optionsOrNil objectForKey:@"minDate"];
-    NSNumber *maxDate = [optionsOrNil objectForKey:@"maxDate"];
     NSString *localeString = [optionsOrNil objectForKey:@"locale"];
     NSString *okTextString = [optionsOrNil objectForKey:@"okText"];
     NSString *cancelTextString = [optionsOrNil objectForKey:@"cancelText"];
     BOOL allowOldDates = [[optionsOrNil objectForKey:@"allowOldDates"] intValue] == 1 ? YES : NO;
     BOOL allowFutureDates = [[optionsOrNil objectForKey:@"allowFutureDates"] intValue] == 1 ? YES : NO;
+    long long nowTicks = ((long long)[[NSDate date] timeIntervalSince1970]) * DDBIntervalFactor;
+    long long minDateTicks = [[optionsOrNil objectForKey:@"minDateTicks"] ?: [NSNumber numberWithLong:(allowOldDates ? DDBMinDate : nowTicks)] longLongValue];
+    long long maxDateTicks = [[optionsOrNil objectForKey:@"maxDateTicks"] ?: [NSNumber numberWithLong:(allowFutureDates ? DDBMaxDate : nowTicks)] longLongValue];
     NSInteger minuteInterval = [[optionsOrNil objectForKey:@"minuteInterval"] intValue];
 
     if (localeString == nil || localeString.length == 0) localeString = @"EN";
@@ -158,15 +159,12 @@
     self.modalPicker.dismissText = okTextString;
     self.modalPicker.cancelText = cancelTextString;
 
-    if (!allowOldDates) datePicker.minimumDate = [NSDate date];
-    if (!allowFutureDates) datePicker.maximumDate = [NSDate date];
-
-    if (minDate != nil && minDate != (id)[NSNull null]) {
-        datePicker.minimumDate = [NSDate dateWithTimeIntervalSince1970:([minDate longLongValue] / 1000)];
+    if (minDateTicks > maxDateTicks)
+    {
+        minDateTicks = DDBMinDate;
     }
-    if (maxDate != nil && maxDate != (id)[NSNull null] && (!(minDate != nil && minDate != (id)[NSNull null]) || maxDate > minDate)) {
-        datePicker.maximumDate = [NSDate dateWithTimeIntervalSince1970:([maxDate longLongValue] / 1000)];
-    }
+    datePicker.minimumDate = [NSDate dateWithTimeIntervalSince1970:(minDateTicks / DDBIntervalFactor)];
+    datePicker.maximumDate = [NSDate dateWithTimeIntervalSince1970:(maxDateTicks / DDBIntervalFactor)];
 
     if ([mode isEqualToString:@"date"])
         datePicker.datePickerMode = UIDatePickerModeDate;
@@ -179,13 +177,13 @@
 
     // Set to something else first, to force an update.
     datePicker.date = [NSDate dateWithTimeIntervalSince1970:0];
-    datePicker.date = [self getRoundedDate:[[NSDate alloc] initWithTimeIntervalSince1970:(ticks / 1000)] minuteInterval:minuteInterval];
+    datePicker.date = [self getRoundedDate:[[NSDate alloc] initWithTimeIntervalSince1970:(ticks / DDBIntervalFactor)] minuteInterval:minuteInterval];
 }
 
 // Sends the date to the plugin javascript handler.
 - (void)callbackSuccessWithJavascript:(NSDate *)date
 {
-    long long ticks = ((long long)(int)[date timeIntervalSince1970]) * 1000;
+    long long ticks = ((long long)[date timeIntervalSince1970]) * DDBIntervalFactor;
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
     [result setObject:[NSNumber numberWithLongLong:ticks] forKey:@"ticks"];
 

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -35,16 +35,16 @@
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         return;
     }
-    
+
     self.callbackId = command.callbackId;
-    
+
     NSMutableDictionary *optionsOrNil = [command.arguments objectAtIndex:command.arguments.count - 1];
-        
+
     [self configureDatePicker:optionsOrNil datePicker:self.modalPicker.datePicker];
-            
+
     // Present the view with our custom transition.
     [self.viewController presentViewController:self.modalPicker animated:YES completion:nil];
-    
+
     isVisible = YES;
 }
 
@@ -56,7 +56,7 @@
         [self callbackCancelWithJavascript];
         isVisible = NO;
     }
-    
+
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
@@ -67,7 +67,7 @@
     if (isVisible) {
         return;
     }
-    
+
     [super onMemoryWarning];
 }
 
@@ -97,24 +97,24 @@
                                          initWithHeaderText:@""
                                          dismissText:@""
                                          cancelText:@""];
-    
+
     picker.modalPresentationStyle = UIModalPresentationCustom;
     picker.transitioningDelegate = self;
 
     __weak ModalPickerViewController* weakPicker = picker;
-    
+
     picker.headerBackgroundColor = [UIColor colorWithRed:0.92f green:0.92f blue:0.92f alpha:0.95f];
-    
+
     picker.dismissedHandler = ^(id sender) {
         [self callbackSuccessWithJavascript:weakPicker.datePicker.date];
         isVisible = NO;
     };
-    
+
     picker.cancelHandler = ^(id sender) {
         [self callbackCancelWithJavascript];
         isVisible = NO;
     };
-    
+
     self.modalPicker = picker;
 }
 
@@ -148,7 +148,7 @@
     BOOL allowOldDates = [[optionsOrNil objectForKey:@"allowOldDates"] intValue] == 1 ? YES : NO;
     BOOL allowFutureDates = [[optionsOrNil objectForKey:@"allowFutureDates"] intValue] == 1 ? YES : NO;
     NSInteger minuteInterval = [[optionsOrNil objectForKey:@"minuteInterval"] intValue];
-    
+
     if (localeString == nil || localeString.length == 0) localeString = @"EN";
     datePicker.locale = [[NSLocale alloc] initWithLocaleIdentifier:localeString];
 
@@ -160,23 +160,23 @@
 
     if (!allowOldDates) datePicker.minimumDate = [NSDate date];
     if (!allowFutureDates) datePicker.maximumDate = [NSDate date];
-    
+
     if (minDate != nil && minDate != (id)[NSNull null]) {
         datePicker.minimumDate = [NSDate dateWithTimeIntervalSince1970:([minDate longLongValue] / 1000)];
     }
     if (maxDate != nil && maxDate != (id)[NSNull null] && (!(minDate != nil && minDate != (id)[NSNull null]) || maxDate > minDate)) {
         datePicker.maximumDate = [NSDate dateWithTimeIntervalSince1970:([maxDate longLongValue] / 1000)];
     }
-    
+
     if ([mode isEqualToString:@"date"])
         datePicker.datePickerMode = UIDatePickerModeDate;
     else if ([mode isEqualToString:@"time"])
         datePicker.datePickerMode = UIDatePickerModeTime;
     else
         datePicker.datePickerMode = UIDatePickerModeDateAndTime;
-    
+
     datePicker.minuteInterval = minuteInterval;
-    
+
     // Set to something else first, to force an update.
     datePicker.date = [NSDate dateWithTimeIntervalSince1970:0];
     datePicker.date = [self getRoundedDate:[[NSDate alloc] initWithTimeIntervalSince1970:(ticks / 1000)] minuteInterval:minuteInterval];
@@ -188,7 +188,7 @@
     long long ticks = ((long long)(int)[date timeIntervalSince1970]) * 1000;
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
     [result setObject:[NSNumber numberWithLongLong:ticks] forKey:@"ticks"];
-    
+
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
 }
@@ -198,7 +198,7 @@
 {
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
     [result setObject:[NSNumber numberWithBool:YES] forKey:@"cancelled"];
-    
+
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
 }

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -30,7 +30,11 @@
 
 - (void)show:(CDVInvokedUrlCommand*)command
 {
-    if (isVisible) return;
+    if (isVisible) {
+        CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION messageAsString:@"A date/time picker dialog is already showing."];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+        return;
+    }
     
     self.callbackId = command.callbackId;
     
@@ -42,6 +46,19 @@
     [self.viewController presentViewController:self.modalPicker animated:YES completion:nil];
     
     isVisible = YES;
+}
+
+- (void)hide:(CDVInvokedUrlCommand*)command
+{
+    if (isVisible) {
+        // Hide the view with our custom transition.
+        [self.modalPicker dismissViewControllerAnimated:true completion:nil];
+        [self callbackCancelWithJavascript];
+        isVisible = NO;
+    }
+    
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)onMemoryWarning

--- a/src/ios/ModalPickerViewController.m
+++ b/src/ios/ModalPickerViewController.m
@@ -46,11 +46,11 @@ const float _buttonMargin = 10;
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
-    
+
     _internalView.backgroundColor = _headerBackgroundColor;
     _headerLabel.textColor = _headerTextColor;
     _headerLabel.text = _headerText;
-    
+
     [_doneButton setTitle:_dismissText forState:UIControlStateNormal];
     [_cancelButton setTitle:_cancelText forState:UIControlStateNormal];
 }
@@ -66,7 +66,7 @@ const float _buttonMargin = 10;
 - (void)createControls {
     self.view.backgroundColor = [UIColor clearColor];
     self.view.opaque = NO;
-    
+
     // Measurements of our internal view.
     CGRect viewFrame = self.view.frame;
     CGSize internalViewSize = CGSizeMake(viewFrame.size.width, _datePickerHeight + _headerBarHeight);
@@ -88,7 +88,7 @@ const float _buttonMargin = 10;
     _doneButton.backgroundColor = [UIColor clearColor];
     _doneButton.titleLabel.font = [UIFont boldSystemFontOfSize:[UIFont systemFontSize] * 1.1];
     [_doneButton addTarget:self action:@selector(doneButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
-    
+
     // Create cancel button.
     _cancelButton = [UIButton buttonWithType:UIButtonTypeSystem];
     _cancelButton.frame = CGRectMake(_buttonMargin, _buttonMargin / 2, _cancelButtonSize.width, _cancelButtonSize.height);
@@ -96,7 +96,7 @@ const float _buttonMargin = 10;
     _cancelButton.backgroundColor = [UIColor clearColor];
     _cancelButton.titleLabel.font = [UIFont systemFontOfSize:[UIFont systemFontSize] * 1.1];
     [_cancelButton addTarget:self action:@selector(cancelButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
-    
+
     // Create the date picker.
     _datePicker = [[UIDatePicker alloc] initWithFrame:CGRectZero];
     _datePicker.frame = CGRectMake(0, _headerBarHeight, internalViewSize.width, _datePickerHeight);
@@ -112,7 +112,7 @@ const float _buttonMargin = 10;
     [_internalView addSubview:_headerLabel];
     [_internalView addSubview:_doneButton];
     [_internalView addSubview:_cancelButton];
-    
+
     [self.view addSubview:_internalView];
 }
 

--- a/src/ios/TransparentCoverVerticalAnimator.m
+++ b/src/ios/TransparentCoverVerticalAnimator.m
@@ -10,12 +10,12 @@
     // Grab the from and to view controllers from the context
     UIViewController *fromViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *toViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
-   
+
     if (self.presenting) {
         fromViewController.view.userInteractionEnabled = NO;
-        
+
         [transitionContext.containerView addSubview:toViewController.view];
-        
+
         CGRect startRect = fromViewController.view.frame;
         startRect.origin.y += startRect.size.height;
         CGRect endRect = fromViewController.view.frame;
@@ -23,7 +23,7 @@
 
         // Start animation.
         toViewController.view.frame = startRect;
-        
+
         [UIView animateWithDuration:[self transitionDuration:transitionContext] animations:^{
             //fromViewController.view.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
             toViewController.view.frame = endRect;
@@ -34,15 +34,15 @@
     }
     else {
         toViewController.view.userInteractionEnabled = YES;
-        
+
         CGRect startRect = toViewController.view.frame;
         startRect.origin = CGPointZero;
         CGRect endRect = fromViewController.view.frame;
         endRect.origin.y += startRect.size.height;
-        
+
         // Start animation.
         fromViewController.view.frame = startRect;
-        
+
         [UIView animateWithDuration:[self transitionDuration:transitionContext] animations:^{
 //            toViewController.view.tintAdjustmentMode = UIViewTintAdjustmentModeAutomatic;
             fromViewController.view.frame = endRect;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,7 +31,7 @@ interface IDatePickerOptions {
 interface DateTimePicker {
 
   /**
-   * Show the plugin with specified options.
+   * Show the date/time picker with specified options.
    *
    * @param {IDatePickerOptions} options
    * @memberof DateTimePicker
@@ -39,7 +39,7 @@ interface DateTimePicker {
   show(options: IDatePickerOptions): void;
 
   /**
-   * Show the plugin with specified options and callbacks.
+   * Show the date/time picker with specified options and callbacks.
    * Legacy way to call the show method, kept for backward compatibility.
    * NOTE: The successCallback and errorCallback respectively will be ignored if the success or error callback is provided on the options argument.
    *
@@ -49,4 +49,14 @@ interface DateTimePicker {
    * @memberof DateTimePicker
    */
   show(options: IDatePickerOptions, successCb: (newDate: Date) => void, errorCb: (err: Error) => void): void;
+  
+  /**
+   * Hide the date/time picker.
+   *
+   * If the picker is currently being shown and a cancel-callback is provided
+   * in the options, the callback will be called when the picker is hidden.
+   *
+   * @memberof DateTimePicker
+   */
+  hide(): void;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -49,7 +49,7 @@ interface DateTimePicker {
    * @memberof DateTimePicker
    */
   show(options: IDatePickerOptions, successCb: (newDate: Date) => void, errorCb: (err: Error) => void): void;
-  
+
   /**
    * Hide the date/time picker.
    *

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,7 +53,7 @@ interface DateTimePicker {
   /**
    * Hide the date/time picker.
    *
-   * If the picker is currently being shown and a cancel-callback is provided
+   * If the picker is currently being shown and a cancel-callback was provided
    * in the options, the callback will be called when the picker is hidden.
    *
    * @memberof DateTimePicker

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -62,7 +62,8 @@ function isNumber(value) {
 }
 
 function isMinuteInterval(i) {
-	return isNumber(i) && i >= 1 && i <= 30 && (60 % i === 0);
+	i = parseInt(i)
+	return isNumber(i) && !isNaN(i) && i >= 1 && i <= 30 && (60 % i === 0);
 }
 
 /**

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -132,7 +132,7 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 /**
  * Hide the date time picker.
  *
- * If the picker is currently being shown and a cancel-callback is provided
+ * If the picker is currently being shown and a cancel-callback was provided
  * in the options, the callback will be called when the picker is hidden.
  */
 DateTimePicker.prototype.hide = function() {

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -27,7 +27,7 @@ var utils = require('cordova/utils'),
 var modeRegex = /(date|time|datetime)/i,
 	isValidMode = modeRegex.test.bind(modeRegex);
 
-function noop() {};
+function noop() { };
 
 function isDate(val) {
 	return Object.prototype.toString.call(val) === "[object Date]" && !isNaN(val.getTime());

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -99,20 +99,20 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 		}.bind(this);
 
 	try {
-		utils.validate(utils.isValidMode, settings, "mode", " Expected a String: date, time, datetime.");
+		utils.validate(utils.isValidMode, settings, "mode", "Expected a String: date, time, datetime.");
 
 		// Validate if dates are valid, convert to ticks since epoch.
-		if (utils.validate(utils.isDate, settings, "date", " Expected a Date.")) {
+		if (utils.validate(utils.isDate, settings, "date", "Expected a Date.")) {
 			settings.ticks = settings.date.valueOf();
 		}
-		if (!!settings.minDate && utils.validate(utils.isDate, settings, "minDate", " Expected a Date.")) {
+		if (!!settings.minDate && utils.validate(utils.isDate, settings, "minDate", "Expected a Date.")) {
 			settings.minDate = settings.minDate.valueOf();
 		}
-		if (!!settings.maxDate && utils.validate(utils.isDate, settings, "maxDate", " Expected a Date.")) {
+		if (!!settings.maxDate && utils.validate(utils.isDate, settings, "maxDate", "Expected a Date.")) {
 			settings.maxDate = settings.maxDate.valueOf();
 		}
 
-		!!settings.minuteInterval && utils.validate(utils.isMinuteInterval, settings, "minuteInterval", " Expected a Number which is a divisor of 60 (min 1, max 30).");
+		!!settings.minuteInterval && utils.validate(utils.isMinuteInterval, settings, "minuteInterval", "Expected a Number which is a divisor of 60 (min 1, max 30).");
 	} catch (e) {
 		onPluginError(e.message);
 		return;

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -77,10 +77,8 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 			// The success handler expects the result to be:
 			//
 			// {
-			//   "result": {
-			//	   "ticks": a 64-bit int (ticks),
-			//	   "cancelled": true|false
-			//   }
+			//    "ticks": a 64-bit int (ticks),
+			//    "cancelled": true|false
 			// }
 			console.debug("DateTimePickerPlugin: Exec 'show' returned:", result);
 			if (utils.isDefined(result) && result !== null) {
@@ -109,10 +107,10 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 			settings.ticks = settings.date.valueOf();
 		}
 		if (!!settings.minDate && utils.validate(utils.isDate, settings, "minDate", "Expected a Date.")) {
-			settings.minDate = settings.minDate.valueOf();
+			settings.minDateTicks = settings.minDate.valueOf();
 		}
 		if (!!settings.maxDate && utils.validate(utils.isDate, settings, "maxDate", "Expected a Date.")) {
-			settings.maxDate = settings.maxDate.valueOf();
+			settings.maxDateTicks = settings.maxDate.valueOf();
 		}
 
 		if (!!settings.minuteInterval && utils.validate(utils.isMinuteInterval, settings, "minuteInterval", "Expected a Number which is a divisor of 60 (min 1, max 30).")) {

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -82,7 +82,7 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 			//	   "cancelled": true|false
 			//   }
 			// }
-
+			console.debug("DateTimePickerPlugin: Exec 'show' returned:", result);
 			if (utils.isDefined(result) && result !== null) {
 				if (utils.isObject(result)) {
 					if (result.cancelled === true) {
@@ -98,8 +98,11 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 			onPluginError("Unexpected result from plugin: " + JSON.stringify(arguments));
 		}.bind(this);
 
+	// Validate/sanitize options.
 	try {
-		utils.validate(utils.isValidMode, settings, "mode", "Expected a String: date, time, datetime.");
+		if (utils.validate(utils.isValidMode, settings, "mode", "Expected a String: date, time, datetime.")) {
+			settings.mode = settings.mode.toLowerCase();
+		};
 
 		// Validate if dates are valid, convert to ticks since epoch.
 		if (utils.validate(utils.isDate, settings, "date", "Expected a Date.")) {
@@ -112,12 +115,19 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 			settings.maxDate = settings.maxDate.valueOf();
 		}
 
-		!!settings.minuteInterval && utils.validate(utils.isMinuteInterval, settings, "minuteInterval", "Expected a Number which is a divisor of 60 (min 1, max 30).");
+		if (!!settings.minuteInterval && utils.validate(utils.isMinuteInterval, settings, "minuteInterval", "Expected a Number which is a divisor of 60 (min 1, max 30).")) {
+			settings.minuteInterval = parseInt(settings.minuteInterval);
+		}
+
+		if (cordova.platformId !== "android") {
+			delete settings.android;
+		}
 	} catch (e) {
 		onPluginError(e.message);
 		return;
 	}
 
+	console.debug("DateTimePickerPlugin: Exec 'show' with:", settings);
 	exec(onPluginSuccess, onPluginError, "DateTimePicker", "show", [ settings ]);
 };
 
@@ -128,6 +138,7 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
  * in the options, the callback will be called when the picker is hidden.
  */
 DateTimePicker.prototype.hide = function() {
+	console.debug("DateTimePickerPlugin: Exec 'hide'.");
 	exec(null, utils.getErrorHandler().bind(this), "DateTimePicker", "hide");
 }
 

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -81,16 +81,14 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 			//    "cancelled": true|false
 			// }
 			console.debug("DateTimePickerPlugin: Exec 'show' returned:", result);
-			if (utils.isDefined(result) && result !== null) {
-				if (utils.isObject(result)) {
-					if (result.cancelled === true) {
-						utils.isFunction(settings.cancel) && settings.cancel.apply(this);
-					} else if (utils.isNumber(result.ticks)) {
-						var resultDate = new Date(result.ticks);
-						utils.isFunction(settings.success) && settings.success.apply(this, [ resultDate ]);
-					}
-					return;
+			if (utils.isDefined(result) && utils.isObject(result) && result !== null) {
+				if (result.cancelled === true) {
+					utils.isFunction(settings.cancel) && settings.cancel.apply(this);
+				} else if (utils.isNumber(result.ticks)) {
+					var resultDate = new Date(result.ticks);
+					utils.isFunction(settings.success) && settings.success.apply(this, [ resultDate ]);
 				}
+				return;
 			}
 
 			onPluginError("Unexpected result from plugin: " + JSON.stringify(arguments));

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -87,7 +87,7 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 						utils.isFunction(settings.cancel) && settings.cancel.apply(this);
 					} else if (utils.isNumber(result.ticks)) {
 						var resultDate = new Date(result.ticks);
-						utils.isDate(resultDate) && utils.isFunction(settings.success) && settings.success.apply(this, [ resultDate ]);
+						utils.isFunction(settings.success) && settings.success.apply(this, [ resultDate ]);
 					}
 					return;
 				}

--- a/www/utils.js
+++ b/www/utils.js
@@ -75,7 +75,11 @@ utils.getErrorHandler = function (callback) {
  */
 utils.validate = function (test, obj, key, message) {
 	if (!test(obj[key])) {
-		throw Error("The value '" + obj[key] + "' for option '" + key + "' is invalid." + (message || ""));
+		var msg = "The value '" + obj[key] + "' for option '" + key + "' is invalid.";
+		if (message) {
+			msg += " " + message;
+		}
+		throw Error(msg);
 	}
 	return true;
 }

--- a/www/utils.js
+++ b/www/utils.js
@@ -58,9 +58,10 @@ function copy() {
 utils.getErrorHandler = function (callback) {
 	return function(err) {
 		if (callback && utils.isFunction(callback)) {
+			console.debug("DateTimePickerPlugin: " + err);
 			callback.apply(this, [ err ]);
 		} else {
-			console.error("DatePickerPlugin: " + err);
+			console.error("DateTimePickerPlugin: " + err);
 		}
 	};
 }

--- a/www/utils.js
+++ b/www/utils.js
@@ -1,0 +1,81 @@
+var cordovaUtils = require('cordova/utils'),
+	utils = exports,
+	modeRegex = /(date|time|datetime)/i;
+
+utils.isValidMode = modeRegex.test.bind(modeRegex);
+
+var is = utils.is = function (value, type) {
+	return typeof value === type;
+}
+
+utils.isDate = function (val) {
+	return cordovaUtils.typeName(val) === "Date" && !isNaN(val.getTime());
+}
+
+utils.isUndefined = function (value) {
+	return is(value, "undefined");
+}
+
+utils.isDefined = function (value) {
+	return !utils.isUndefined(value);
+}
+
+utils.isFunction = function (value) {
+	return is(value, "function");
+}
+
+utils.isObject = function (value) {
+	return is(value, "object");
+}
+
+utils.isString = function (value) {
+	return is(value, "string");
+}
+
+utils.isNumber = function (value) {
+	return is(value, "number");
+}
+
+utils.isMinuteInterval = function (i) {
+	i = parseInt(i)
+	return utils.isNumber(i) && !isNaN(i) && i >= 1 && i <= 30 && (60 % i === 0);
+}
+
+function copy() {
+	var dst = arguments[0],
+		src = arguments.slice.call()
+
+    for (var key in obj) {
+		if (utils.isDefined(options[key]))
+			settings[key] = options[key];
+	}
+}
+
+/**
+ * Returns an error handler that logs to console if no callback is provided.
+ * @param {Function} callback The external callback to call on error.
+ */
+utils.getErrorHandler = function (callback) {
+	return function(err) {
+		if (callback && utils.isFunction(callback)) {
+			callback.apply(this, [ err ]);
+		} else {
+			console.error("DatePickerPlugin: " + err);
+		}
+	};
+}
+
+/**
+ * Validates obj[key] using the provided test. If the test fails, an Error is thrown.
+ * @param {Function} test 	The test to execute.
+ * @param {Object} obj 		The object to check a value on.
+ * @param {String} key 		The key of the value to test.
+ * @param {String} message 	The optional error message to append to the default error message.
+ * @return			 		true if the test passes. Never returns false (instead will throw).
+ */
+utils.validate = function (test, obj, key, message) {
+	if (!test(obj[key])) {
+		throw Error("The value '" + obj[key] + "' for option '" + key + "' is invalid." + (message || ""));
+	}
+	return true;
+}


### PR DESCRIPTION
**New**
- Add support to hide the picker from code
- Android: add support for allowFutureDates/allowOldDates

**Fixes**
- Android/iOS: fix minDate/maxDate to support dates older than 1-1-1970

**Improvements**
- Validate and sanitize options

**Breaking**
- Android: requires API level 26 (https://developer.android.com/distribute/best-practices/develop/target-sdk)