### PR TITLE
v2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,27 @@
 
 Changelog for [skwas-cordova-plugin-datetimepicker](./README.md).
 
+## 2.1.0
+
+### New
+
+- Android/iOS: add `clearText` property which - when specified - adds a button with intend to clear the current date. When the user taps this button, the `success` callback will be called with an `undefined` date and the picker is closed. Backwards compatible due to having to opt-in.
+- Android/iOS: add `titleText` property which when specified sets the dialog title.
+
+### Changes
+
+- Android/iOS: remove default button texts, instead use OS defaults.
+- iOS: remove default locale, instead use the user locale.
+
+### Fixes
+
+- iOS: (#33) fix picker sometimes showing 1 januari when using `minuteInterval` > 1 and `allowOldDates` or `allowFutureDates` is set to `false`.
+
 ## 2.0.1
 
 ### Fixes
 
-- fix: Lower API level 26 requirement introduced in v2.0.0 down to API level 19.
+- Android: Lower API level 26 requirement introduced in v2.0.0 down to API level 19.
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,20 @@ Changelog for [skwas-cordova-plugin-datetimepicker](./README.md).
 
 ### New
 
+- iOS: added iOS 13 dark mode support ([#35](https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker/issues/35)).
 - Android/iOS: add `clearText` property which - when specified - adds a button with intend to clear the current date. When the user taps this button, the `success` callback will be called with an `undefined` date and the picker is closed. Backwards compatible due to having to opt-in.
 - Android/iOS: add `titleText` property which when specified sets the dialog title.
 
 ### Changes
 
-- Android/iOS: remove default button texts, instead use OS defaults.
-- iOS: remove default locale, instead use the user locale.
+- Android/iOS: removed default button texts. Instead, now OS defaults are used.
+- iOS: removed default locale 'EN'. Instead, the user locale is used.
+- iOS: refactored to use `UINavigationBar` and Auto Layout.
+- iOS: made modal background slightly less opaque.
 
 ### Fixes
 
-- iOS: (#33) fix picker sometimes showing 1 januari when using `minuteInterval` > 1 and `allowOldDates` or `allowFutureDates` is set to `false`.
+- iOS: ([#33](https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker/issues/33)) fix picker sometimes showing 1 januari when using `minuteInterval` > 1 and `allowOldDates` or `allowFutureDates` is set to `false`.
 
 ## 2.0.1
 
@@ -46,7 +49,7 @@ Changelog for [skwas-cordova-plugin-datetimepicker](./README.md).
 
 ## 1.1.3
 
-- Android: Due to a [known bug](https://issuetracker.google.com/issues/36951008), when cancelling on Jelly Bean and KitKat, the cancel callback was not called. Instead the success callback was called. Fixes #18.
+- Android: Due to a [known bug](https://issuetracker.google.com/issues/36951008), when cancelling on Jelly Bean and KitKat, the cancel callback was not called. Instead the success callback was called. Fixes [#18](https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker/issues/18).
 
 ## 1.1.2
 
@@ -74,7 +77,7 @@ Changelog for [skwas-cordova-plugin-datetimepicker](./README.md).
 
 ## 0.9.0
 
-- Android: fixed datetime mode only showing date picker (see #10)
+- Android: fixed datetime mode only showing date picker (see [#10](https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker/issues/10))
 - Android: added theme support
 - Android: added calendar switch
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,17 @@ This was the original way to call the plugin, and is kept for compatibility.
 | minDate             | Date                |                | ![Supported][supported]    | ![Supported][supported]    | Set the minimum date that can be selected |
 | maxDate             | Date                |                | ![Supported][supported]    | ![Supported][supported]    | Set the maximum date that can be selected |
 | minuteInterval      | int                 | 1              | >= Honeycomb               | ![Supported][supported]    | For minute spinner the number of minutes per step |
-| locale              | String              | "EN"           | -                          | ![Supported][supported]    | The locale to use for text and date/time |
-| okText              | String              | "Select"       | ![Supported][supported]    | ![Supported][supported]    | The text to use for the ok button |
-| cancelText          | String              | "Cancel"       | ![Supported][supported]    | ![Supported][supported]    | The text to use for the cancel button |
-| clearText           | String              |                | ![Supported][supported]    |                            | The text to use for the clear button |
-| titleText           | String              |                | Depends&#160;on&#160;theme |                            | The text to use for the dialog title |
+| locale              | String              | (user default) | -                          | ![Supported][supported]    | The locale to use for text and date/time |
+| okText              | String              | (os default)   | ![Supported][supported]    | ![Supported][supported]    | The text to use for the ok button |
+| cancelText          | String              | (os default)   | ![Supported][supported]    | ![Supported][supported]    | The text to use for the cancel button |
+| clearText           | String              |                | ![Supported][supported]    | ![Supported][supported]    | The text to use for the clear button |
+| titleText           | String              |                | Depends&#160;on&#160;theme | ![Supported][supported]    | The text to use for the dialog title |
 | success             | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The success callback |
 | cancel              | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The cancel callback |
 | error               | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The error callback |
 | android             | Object              | {}             | optional                   | ignored                    | Android specific options |
+
+> When providing the `clearText` property, an extra button is shown with intend to clear the current date. When the user taps this button, the `success` callback will be called with an `undefined` date. From a UI perspective, this button should be hidden by application code when no date is currently set by omitting the property, but this is up to you.
 
 #### Android options
 
@@ -71,42 +73,15 @@ function onDeviceReady() {
 
     cordova.plugins.DateTimePicker.show({
         mode: "date",
-        date: myDate,
-        allowOldDates: true,
-        allowFutureDates: true,
-        minDate: new Date(),
-        maxDate: null,
-        minuteInterval: 15,
-        locale: "EN",
-        okText: "Select",
-        cancelText: "Cancel",
-        clearText: "Clear",
-        android: {
-            theme: 16974126, // Theme_DeviceDefault_Dialog
-            is24HourView: true
-        },
+        date: myDate
         success: function(newDate) {
             // Handle new date.
-            if (typeof newDate === "undefined") {
-                console.info("Date is cleared.");
-            }
-            else {
-                console.info(newDate);
-            }
+            console.info(newDate);
             myDate = newDate;
-        },
-        cancel: function() {
-            console.info("Cancelled");
-        },
-        error: function (err) {
-            // Handle error.
-            console.error(err);
         }
     });
 }
 ```
-
-> When the `clearText` property is provided, an extra button will be shown to clear the date. When the user taps the button, the dialog is closed and the `success` callback called with an `undefined` date.
 
 ### hide
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This was the original way to call the plugin, and is kept for compatibility.
 | locale              | String              | "EN"           | -                          | ![Supported][supported]    | The locale to use for text and date/time |
 | okText              | String              | "Select"       | ![Supported][supported]    | ![Supported][supported]    | The text to use for the ok button |
 | cancelText          | String              | "Cancel"       | ![Supported][supported]    | ![Supported][supported]    | The text to use for the cancel button |
+| clearText           | String              |                | ![Supported][supported]    |                            | The text to use for the clear button |
 | success             | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The success callback |
 | cancel              | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The cancel callback |
 | error               | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The error callback |
@@ -78,13 +79,19 @@ function onDeviceReady() {
         locale: "EN",
         okText: "Select",
         cancelText: "Cancel",
+        clearText: "Clear",
         android: {
             theme: 16974126, // Theme_DeviceDefault_Dialog
             is24HourView: true
         },
         success: function(newDate) {
             // Handle new date.
-            console.info(newDate);
+            if (typeof newDate === "undefined") {
+                console.info("Date is cleared.");
+            }
+            else {
+                console.info(newDate);
+            }
             myDate = newDate;
         },
         cancel: function() {
@@ -97,6 +104,8 @@ function onDeviceReady() {
     });
 }
 ```
+
+> When the `clearText` property is provided, an extra button will be shown to clear the date. When the user taps the button, the dialog is closed and the `success` callback called with an `undefined` date.
 
 ### hide
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This was the original way to call the plugin, and is kept for compatibility.
 | okText              | String              | "Select"       | ![Supported][supported]    | ![Supported][supported]    | The text to use for the ok button |
 | cancelText          | String              | "Cancel"       | ![Supported][supported]    | ![Supported][supported]    | The text to use for the cancel button |
 | clearText           | String              |                | ![Supported][supported]    |                            | The text to use for the clear button |
+| titleText           | String              |                | Depends&#160;on&#160;theme |                            | The text to use for the dialog title |
 | success             | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The success callback |
 | cancel              | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The cancel callback |
 | error               | Function            | -              | ![Supported][supported]    | ![Supported][supported]    | The error callback |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "skwas-cordova-plugin-datetimepicker",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.1",
+  "version": "2.1.0",
   "name": "skwas-cordova-plugin-datetimepicker",
   "cordova_name": "DateTime picker",
   "description": "Cordova DateTime picker plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="skwas-cordova-plugin-datetimepicker"
-    version="2.0.1">
+    version="2.1.0">
     <name>DateTime picker</name>
     <description>Cordova DateTime picker plugin</description>
     <license>MIT</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -68,6 +68,8 @@ THE SOFTWARE.
         <source-file src="src/ios/ModalPickerViewController.m" />
         <header-file src="src/ios/TransparentCoverVerticalAnimator.h" />
         <source-file src="src/ios/TransparentCoverVerticalAnimator.m" />
+        <header-file src="src/ios/Extensions.h" />
+        <source-file src="src/ios/Extensions.m" />
     </platform>
 
     <!-- browser -->

--- a/src/android/DatePickerDialog.java
+++ b/src/android/DatePickerDialog.java
@@ -7,6 +7,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
+import android.text.TextUtils;
 import android.widget.DatePicker;
 
 import java.lang.reflect.Method;
@@ -18,6 +19,7 @@ public class DatePickerDialog extends android.app.DatePickerDialog {
 	private final static boolean mShouldFixCallbackDelegate = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
 	private final OnDateSetListener mListener;
 	private DatePicker mDatePicker;
+	private CharSequence mTitle;
 
 	public DatePickerDialog(@NonNull Context context, @Nullable OnDateSetListener listener, int year, int monthOfYear, int dayOfMonth) {
 		super(context, patchListener(listener), year, monthOfYear, dayOfMonth);
@@ -80,6 +82,23 @@ public class DatePickerDialog extends android.app.DatePickerDialog {
 			setSpinnersShown.invoke(dp, !enabled);
 		} catch (Exception ex) {
 			//ex.printStackTrace();
+		}
+	}
+
+	public void setPermanentTitle(CharSequence title) {
+		mTitle = title;
+		if (!TextUtils.isEmpty(mTitle)) {
+			setTitle(title);
+		}
+	}
+
+	@Override
+	public void onDateChanged(@NonNull DatePicker view, int year, int month, int dayOfMonth) {
+		super.onDateChanged(view, year, month, dayOfMonth);
+
+		// If set, enforce title.
+		if (!TextUtils.isEmpty(mTitle)) {
+			setTitle(mTitle);
 		}
 	}
 

--- a/src/android/DateTimePicker.java
+++ b/src/android/DateTimePicker.java
@@ -40,6 +40,7 @@ public class DateTimePicker extends CordovaPlugin {
 		public boolean allowFutureDates = true;
 		public int minuteInterval = 1;
 		public String locale = "EN";
+		public String titleText = null;
 		public String okText = null;
 		public String cancelText = null;
 		public String clearText = null;
@@ -72,6 +73,10 @@ public class DateTimePicker extends CordovaPlugin {
 					: (maxDate = allowFutureDates ? _maxSupportedDate : now);
 
 			minuteInterval = obj.optInt("minuteInterval", minuteInterval);
+
+			if (!obj.isNull("titleText")) {
+				titleText = obj.optString("titleText");
+			}
 
 			if (!obj.isNull("okText")) {
 				okText = obj.optString("okText");
@@ -242,6 +247,7 @@ public class DateTimePicker extends CordovaPlugin {
 						calendar.get(Calendar.DAY_OF_MONTH)
 				);
 
+				dateDialog.setPermanentTitle(options.titleText);
 				dateDialog.setOkText(options.okText);
 				dateDialog.setCancelText(options.cancelText);
 				dateDialog.setCalendarEnabled(options.calendar);
@@ -291,7 +297,7 @@ public class DateTimePicker extends CordovaPlugin {
 		if (TextUtils.isEmpty(clearText)) {
 			return;
 		}
-		
+
 		dialog.setButton(DialogInterface.BUTTON_NEUTRAL, clearText, new DialogInterface.OnClickListener() {
 			@Override
 			public void onClick(DialogInterface dialog, int which) {

--- a/src/android/DateTimePicker.java
+++ b/src/android/DateTimePicker.java
@@ -42,6 +42,7 @@ public class DateTimePicker extends CordovaPlugin {
 		public String locale = "EN";
 		public String okText = null;
 		public String cancelText = null;
+		public String clearText = null;
 
 		// Android specific
 		public int theme = android.R.style.Theme_DeviceDefault_Dialog;
@@ -81,6 +82,10 @@ public class DateTimePicker extends CordovaPlugin {
 				cancelText = obj.optString("cancelText");
 			}
 			cancelText = TextUtils.isEmpty(cancelText) ? _activity.getString(android.R.string.cancel) : cancelText;
+
+			if (!obj.isNull("clearText")) {
+				clearText = obj.optString("clearText");
+			}
 
 			JSONObject androidOptions = obj.optJSONObject("android");
 			if (androidOptions != null) {
@@ -218,7 +223,7 @@ public class DateTimePicker extends CordovaPlugin {
 				timeDialog.setOkText(options.okText);
 				timeDialog.setCancelText(options.cancelText);
 
-				showDialog(timeDialog, callbackContext);
+				showDialog(timeDialog, callbackContext, options);
 			}
 		};
 	}
@@ -246,7 +251,7 @@ public class DateTimePicker extends CordovaPlugin {
 				dp.setMinDate(options.minDate.getTime());
 				dp.setMaxDate(options.maxDate.getTime());
 
-				showDialog(dateDialog, callbackContext);
+				showDialog(dateDialog, callbackContext, options);
 			}
 		};
 	}
@@ -257,9 +262,11 @@ public class DateTimePicker extends CordovaPlugin {
 	 * @param dialog          The dialog to show.
 	 * @param callbackContext The callback context.
 	 */
-	private synchronized void showDialog(final AlertDialog dialog, final CallbackContext callbackContext) {
+	private synchronized void showDialog(final AlertDialog dialog, final CallbackContext callbackContext, final DateTimePickerOptions options) {
 		dialog.setCancelable(true);
 		dialog.setCanceledOnTouchOutside(false);
+
+		setClearButton(dialog, callbackContext, options.clearText);
 
 		dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
 			@Override
@@ -278,6 +285,24 @@ public class DateTimePicker extends CordovaPlugin {
 
 		_dialog = dialog;
 		dialog.show();
+	}
+
+	private void setClearButton(AlertDialog dialog, CallbackContext callbackContext, String clearText) {
+		if (TextUtils.isEmpty(clearText)) {
+			return;
+		}
+		
+		dialog.setButton(DialogInterface.BUTTON_NEUTRAL, clearText, new DialogInterface.OnClickListener() {
+			@Override
+			public void onClick(DialogInterface dialog, int which) {
+				try {
+					// Send empty object.
+					callbackContext.success(new JSONObject());
+				} finally {
+					_runnable = null;
+				}
+			}
+		});
 	}
 
 	/**

--- a/src/android/TimePickerDialog.java
+++ b/src/android/TimePickerDialog.java
@@ -4,6 +4,9 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.text.TextUtils;
+import android.widget.DatePicker;
 import android.widget.NumberPicker;
 import android.widget.TimePicker;
 
@@ -13,12 +16,13 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class TimePickerDialog extends android.app.TimePickerDialog {
-	final OnTimeSetListener mCallback;
-	final int mIncrement;
-	final int mHourOfDay, mMinute;
-	TimePicker mTimePicker;
+	private final OnTimeSetListener mCallback;
+	private final int mIncrement;
+	private final int mHourOfDay, mMinute;
+	private TimePicker mTimePicker;
+	private CharSequence mTitle;
 	// In Honeycomb upwards, we have access to the time picker. In Lollipop, the time picker has changed to a radial picker, and we can't change the interval.
-	boolean mIsSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
+	private boolean mIsSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB;
 
 	public TimePickerDialog(Context context, OnTimeSetListener callBack, int hourOfDay, int minute, boolean is24HourView, int increment) {
 		super(context, callBack, hourOfDay, minute, is24HourView);
@@ -62,6 +66,11 @@ public class TimePickerDialog extends android.app.TimePickerDialog {
 	@Override
 	public void onTimeChanged(TimePicker view, int hourOfDay, int minute) {
 		super.onTimeChanged(view, hourOfDay, mIsSupported ? minute * mIncrement : minute);
+
+		// If set, enforce title.
+		if (!TextUtils.isEmpty(mTitle)) {
+			setTitle(mTitle);
+		}
 	}
 
 	@Override
@@ -114,5 +123,12 @@ public class TimePickerDialog extends android.app.TimePickerDialog {
 
 	public void setCancelText(String text) {
 		setButton(BUTTON_NEGATIVE, text, this);
+	}
+
+	public void setPermanentTitle(CharSequence title) {
+		mTitle = title;
+		if (!TextUtils.isEmpty(mTitle)) {
+			setTitle(title);
+		}
 	}
 }

--- a/src/ios/DateTimePicker.h
+++ b/src/ios/DateTimePicker.h
@@ -3,20 +3,16 @@
 #import "ModalPickerViewController.h"
 
 enum DTPDateBounds {
-    DDBMinDate = -8640000000000000,
-    DDBMaxDate = 8640000000000000,
     DDBIntervalFactor = 1000
 };
 
 @interface DateTimePicker : CDVPlugin <UIViewControllerTransitioningDelegate> {
-   
 }
     
-@property (strong) ModalPickerViewController* modalPicker;
-
 - (void)show:(CDVInvokedUrlCommand*)command;
-
 - (void)hide:(CDVInvokedUrlCommand*)command;
+
+@property (strong) ModalPickerViewController* modalPicker;
 
 @end
 

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -5,39 +5,31 @@
 
 @interface DateTimePicker() // (Private)
 
-
-// Configures the UIDatePicker with the NSMutableDictionary options
+// Configures the UIDatePicker with the NSMutableDictionary options.
 - (void)configureDatePicker:(NSMutableDictionary *)optionsOrNil datePicker:(UIDatePicker *)datePicker;
-
-
-@property (readwrite, assign) BOOL isVisible;
-@property (strong) NSString* callbackId;
 
 @end
 
 
-@implementation DateTimePicker
-
-
-@synthesize isVisible, callbackId;
-
+@implementation DateTimePicker {
+    BOOL _isVisible;
+    NSString *_callbackId;
+}
 
 #pragma mark - Public Methods
-
 
 - (void)pluginInitialize {
     [self initPickerView:self.webView.superview];
 }
 
-- (void)show:(CDVInvokedUrlCommand*)command
-{
-    if (isVisible) {
+- (void)show:(CDVInvokedUrlCommand*)command {
+    if (_isVisible) {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ILLEGAL_ACCESS_EXCEPTION messageAsString:@"A date/time picker dialog is already showing."];
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
         return;
     }
 
-    self.callbackId = command.callbackId;
+    _callbackId = command.callbackId;
 
     NSMutableDictionary *optionsOrNil = [command.arguments objectAtIndex:command.arguments.count - 1];
 
@@ -46,163 +38,135 @@
     // Present the view with our custom transition.
     [self.viewController presentViewController:self.modalPicker animated:YES completion:nil];
 
-    isVisible = YES;
+    _isVisible = YES;
 }
 
-- (void)hide:(CDVInvokedUrlCommand*)command
-{
-    if (isVisible) {
+- (void)hide:(CDVInvokedUrlCommand*)command {
+    if (_isVisible) {
         // Hide the view with our custom transition.
         [self.modalPicker dismissViewControllerAnimated:true completion:nil];
         [self callbackCancelWithJavascript];
-        isVisible = NO;
+        _isVisible = NO;
     }
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_NO_RESULT];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
-- (void)onMemoryWarning
-{
-    // It could be better to close the datepicker before the system clears memory. But in reality, other non-visible plugins should be tidying themselves at this point. This could cause a fatal at runtime.
-    if (isVisible) {
-        return;
-    }
-
-    [super onMemoryWarning];
-}
-
-
 #pragma mark UIViewControllerTransitioningDelegate methods
 
 - (id<UIViewControllerAnimatedTransitioning>)animationControllerForPresentedController:(UIViewController *)presented
                                                                   presentingController:(UIViewController *)presenting
-                                                                      sourceController:(UIViewController *)source
-{
+                                                                      sourceController:(UIViewController *)source {
     TransparentCoverVerticalAnimator *animator = [TransparentCoverVerticalAnimator new];
     animator.presenting = YES;
     return animator;
 }
 
-- (id<UIViewControllerAnimatedTransitioning>)animationControllerForDismissedController:(UIViewController *)dismissed
-{
+- (id<UIViewControllerAnimatedTransitioning>)animationControllerForDismissedController:(UIViewController *)dismissed {
     TransparentCoverVerticalAnimator *animator = [TransparentCoverVerticalAnimator new];
     return animator;
 }
 
 #pragma mark - Private Methods
 
-- (void)initPickerView:(UIView*)theWebView
-{
+- (void)initPickerView:(UIView*)theWebView {
     ModalPickerViewController *picker = [[ModalPickerViewController alloc] init];
 
     picker.modalPresentationStyle = UIModalPresentationCustom;
     picker.transitioningDelegate = self;
 
-    picker.dismissedHandler = ^(id sender) {
+    picker.doneHandler = ^(id sender) {
         ModalPickerViewController *modelPicker = (ModalPickerViewController *)sender;
-        if (modelPicker == nil)
-        {
+        if (modelPicker == nil) {
             [self callbackSuccessWithJavascript:nil];
-        }
-        else
-        {
+        } else {
             [self callbackSuccessWithJavascript:modelPicker.datePicker.date];
         }
-        isVisible = NO;
+        _isVisible = NO;
     };
 
     picker.cancelHandler = ^() {
         [self callbackCancelWithJavascript];
-        isVisible = NO;
+        _isVisible = NO;
     };
 
     self.modalPicker = picker;
 }
 
-- (void)configureDatePicker:(NSMutableDictionary *)optionsOrNil datePicker:(UIDatePicker *)datePicker;
-{
-    long long ticks = [[optionsOrNil objectForKey:@"ticks"] longLongValue];
+- (void)configureDatePicker:(NSMutableDictionary *)optionsOrNil datePicker:(UIDatePicker *)datePicker {
     
-    // Locale
+    // Mode (must be set first, otherwise minuteInterval > 1 acts wonky).
+    NSString *mode = [optionsOrNil objectForKey:@"mode"];
+    if ([mode isEqualToString:@"date"]) {
+        datePicker.datePickerMode = UIDatePickerModeDate;
+    } else if ([mode isEqualToString:@"time"]) {
+        datePicker.datePickerMode = UIDatePickerModeTime;
+    } else {
+        datePicker.datePickerMode = UIDatePickerModeDateAndTime;
+    }
+   
+    // Locale.
     NSString *localeString = [optionsOrNil objectForKeyNotNull:@"locale"];
-    if (localeString.length > 0)
-    {
-        datePicker.locale = [[NSLocale alloc] initWithLocaleIdentifier:localeString];
-    }
-    else
-    {
-        datePicker.locale = [NSLocale currentLocale];
-    }
+    datePicker.locale = localeString.length > 0 ? [[NSLocale alloc] initWithLocaleIdentifier:localeString] : [NSLocale currentLocale];
     
-    // Texts
-    self.modalPicker.dismissText = [optionsOrNil objectForKeyNotNull:@"okText"];
+    // Texts.
+    self.modalPicker.doneText = [optionsOrNil objectForKeyNotNull:@"okText"];
     self.modalPicker.cancelText = [optionsOrNil objectForKeyNotNull:@"cancelText"];
     self.modalPicker.clearText = [optionsOrNil objectForKeyNotNull:@"clearText"];
     self.modalPicker.titleText = [optionsOrNil objectForKeyNotNull:@"titleText"];
 
-    // Minute interval
+    // Minute interval.
     NSInteger minuteInterval = [[optionsOrNil objectForKeyNotNull:@"minuteInterval"] ?: [NSNumber numberWithInt:1] intValue];
     datePicker.minuteInterval = minuteInterval;
     
-    // Allow old/future dates
-    BOOL allowOldDates = ([[optionsOrNil objectForKeyNotNull:@"allowOldDates"] ?: [NSNumber numberWithInt:1] intValue]) == 1 ? YES : NO;
-    BOOL allowFutureDates = ([[optionsOrNil objectForKeyNotNull:@"allowFutureDates"] ?: [NSNumber numberWithInt:1] intValue]) == 1 ? YES : NO;
+    // Allow old/future dates.
+    BOOL allowOldDates = [[optionsOrNil objectForKeyNotNull:@"allowOldDates"] ?: [NSNumber numberWithInt:1] boolValue];
+    BOOL allowFutureDates = [[optionsOrNil objectForKeyNotNull:@"allowFutureDates"] ?: [NSNumber numberWithInt:1] boolValue];
     
-    // Min/max dates
+    // Min/max dates.
     NSDate *today = [NSDate today];
     long long todayTicks = ((long long)[today timeIntervalSince1970]) * DDBIntervalFactor;
     long long endOfTodayTicks = ((long long)[[[today addDay:1] addSecond:-1] timeIntervalSince1970]) * DDBIntervalFactor;
-    long long minDateTicks = [[optionsOrNil objectForKeyNotNull:@"minDateTicks"] ?: [NSNumber numberWithLongLong:(allowOldDates ? DDBMinDate : todayTicks)] longLongValue];
-    long long maxDateTicks = [[optionsOrNil objectForKeyNotNull:@"maxDateTicks"] ?: [NSNumber numberWithLongLong:(allowFutureDates ? DDBMaxDate : endOfTodayTicks)] longLongValue];
-    if (minDateTicks > maxDateTicks)
-    {
-        minDateTicks = DDBMinDate;
+    NSNumber *minDateTicks = [optionsOrNil objectForKeyNotNull:@"minDateTicks"] ?: allowOldDates ? nil : [NSNumber numberWithLongLong:(todayTicks)];
+    NSNumber *maxDateTicks = [optionsOrNil objectForKeyNotNull:@"maxDateTicks"] ?: allowFutureDates ? nil : [NSNumber numberWithLongLong:(endOfTodayTicks)];
+
+    if (minDateTicks) {
+        datePicker.minimumDate = [[NSDate dateWithTimeIntervalSince1970:([minDateTicks longLongValue] / DDBIntervalFactor)] roundDownToMinuteInterval:minuteInterval];
+    } else {
+        datePicker.minimumDate = nil;
     }
-    datePicker.minimumDate = [[NSDate dateWithTimeIntervalSince1970:(minDateTicks / DDBIntervalFactor)] roundDownToMinuteInterval:minuteInterval];
-    datePicker.maximumDate = [[NSDate dateWithTimeIntervalSince1970:(maxDateTicks / DDBIntervalFactor)] roundUpToMinuteInterval:minuteInterval];
-    
-    // Mode
-    NSString *mode = [optionsOrNil objectForKey:@"mode"];
-    if ([mode isEqualToString:@"date"])
-    {
-        datePicker.datePickerMode = UIDatePickerModeDate;
-    }
-    else if ([mode isEqualToString:@"time"])
-    {
-        datePicker.datePickerMode = UIDatePickerModeTime;
-    }
-    else
-    {
-        datePicker.datePickerMode = UIDatePickerModeDateAndTime;
+    if (maxDateTicks) {
+        datePicker.maximumDate = [[NSDate dateWithTimeIntervalSince1970:([maxDateTicks longLongValue] / DDBIntervalFactor)] roundUpToMinuteInterval:minuteInterval];
+    } else {
+        datePicker.maximumDate = nil;
     }
     
+    // Selected date.
+    long long ticks = [[optionsOrNil objectForKey:@"ticks"] longLongValue];
     [datePicker setDate:[[NSDate dateWithTimeIntervalSince1970:(ticks / DDBIntervalFactor)] roundToMinuteInterval:minuteInterval] animated:FALSE];
 }
 
 // Sends the date to the plugin javascript handler.
-- (void)callbackSuccessWithJavascript:(NSDate *)date
-{
+- (void)callbackSuccessWithJavascript:(NSDate *)date {
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
     // When date is nil, user clicked 'clear' button so we dispatch success without ticks in that case.
-    if (date != nil)
-    {
+    if (date != nil) {
         long long ticks = ((long long)[date timeIntervalSince1970]) * DDBIntervalFactor;
         [result setObject:[NSNumber numberWithLongLong:ticks] forKey:@"ticks"];
     }
     
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
 }
 
 // Sends a cancellation notification to the plugin javascript handler.
-- (void)callbackCancelWithJavascript
-{
+- (void)callbackCancelWithJavascript {
     NSMutableDictionary *result = [[NSMutableDictionary alloc] init];
     [result setObject:[NSNumber numberWithBool:YES] forKey:@"cancelled"];
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
-    [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
 }
 
 @end

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -1,4 +1,5 @@
 #import "DateTimePicker.h"
+#import "Extensions.h"
 #import "ModalPickerViewController.h"
 #import "TransparentCoverVerticalAnimator.h"
 
@@ -138,41 +139,64 @@
 
 - (void)configureDatePicker:(NSMutableDictionary *)optionsOrNil datePicker:(UIDatePicker *)datePicker;
 {
-    NSString *mode = [optionsOrNil objectForKey:@"mode"];
     long long ticks = [[optionsOrNil objectForKey:@"ticks"] longLongValue];
-    NSString *localeString = [optionsOrNil objectForKey:@"locale"];
-    NSString *okTextString = [optionsOrNil objectForKey:@"okText"];
-    NSString *cancelTextString = [optionsOrNil objectForKey:@"cancelText"];
-    BOOL allowOldDates = [[optionsOrNil objectForKey:@"allowOldDates"] intValue] == 1 ? YES : NO;
-    BOOL allowFutureDates = [[optionsOrNil objectForKey:@"allowFutureDates"] intValue] == 1 ? YES : NO;
-    long long nowTicks = ((long long)[[NSDate date] timeIntervalSince1970]) * DDBIntervalFactor;
-    long long minDateTicks = [[optionsOrNil objectForKey:@"minDateTicks"] ?: [NSNumber numberWithLong:(allowOldDates ? DDBMinDate : nowTicks)] longLongValue];
-    long long maxDateTicks = [[optionsOrNil objectForKey:@"maxDateTicks"] ?: [NSNumber numberWithLong:(allowFutureDates ? DDBMaxDate : nowTicks)] longLongValue];
-    NSInteger minuteInterval = [[optionsOrNil objectForKey:@"minuteInterval"] intValue];
-
-    if (localeString == nil || localeString.length == 0) localeString = @"EN";
+    
+    // Locale
+    NSString *localeString = [optionsOrNil objectForKeyNotNull:@"locale"] ?: @"";
+    if (localeString.length == 0)
+    {
+        localeString = @"EN";
+    }
     datePicker.locale = [[NSLocale alloc] initWithLocaleIdentifier:localeString];
-
-    if (okTextString == nil || okTextString.length == 0) okTextString = @"Select";
-    if (cancelTextString == nil || cancelTextString.length == 0) cancelTextString = @"Cancel";
-
+    
+    // OK
+    NSString *okTextString = [optionsOrNil objectForKeyNotNull:@"okText"] ?: @"";
+    if (okTextString.length == 0)
+    {
+        okTextString = @"Select";
+    }
     self.modalPicker.dismissText = okTextString;
+    
+    // Cancel
+    NSString *cancelTextString = [optionsOrNil objectForKeyNotNull:@"cancelText"] ?: @"";
+    if (cancelTextString.length == 0)
+    {
+        cancelTextString = @"Cancel";
+    }
     self.modalPicker.cancelText = cancelTextString;
-
+    
+    // Allow old/future dates
+    BOOL allowOldDates = ([[optionsOrNil objectForKeyNotNull:@"allowOldDates"] ?: [NSNumber numberWithInt:1] intValue]) == 1 ? YES : NO;
+    BOOL allowFutureDates = ([[optionsOrNil objectForKeyNotNull:@"allowFutureDates"] ?: [NSNumber numberWithInt:1] intValue]) == 1 ? YES : NO;
+    
+    // Min/max dates
+    long long nowTicks = ((long long)[[NSDate date] timeIntervalSince1970]) * DDBIntervalFactor;
+    long long minDateTicks = [[optionsOrNil objectForKeyNotNull:@"minDateTicks"] ?: [NSNumber numberWithLong:(allowOldDates ? DDBMinDate : nowTicks)] longLongValue];
+    long long maxDateTicks = [[optionsOrNil objectForKeyNotNull:@"maxDateTicks"] ?: [NSNumber numberWithLong:(allowFutureDates ? DDBMaxDate : nowTicks)] longLongValue];
     if (minDateTicks > maxDateTicks)
     {
         minDateTicks = DDBMinDate;
     }
     datePicker.minimumDate = [NSDate dateWithTimeIntervalSince1970:(minDateTicks / DDBIntervalFactor)];
     datePicker.maximumDate = [NSDate dateWithTimeIntervalSince1970:(maxDateTicks / DDBIntervalFactor)];
-
+    
+    // Mode
+    NSString *mode = [optionsOrNil objectForKey:@"mode"];
     if ([mode isEqualToString:@"date"])
+    {
         datePicker.datePickerMode = UIDatePickerModeDate;
+    }
     else if ([mode isEqualToString:@"time"])
+    {
         datePicker.datePickerMode = UIDatePickerModeTime;
+    }
     else
+    {
         datePicker.datePickerMode = UIDatePickerModeDateAndTime;
-
+    }
+    
+    // Minute interval
+    NSInteger minuteInterval = [[optionsOrNil objectForKeyNotNull:@"minuteInterval"] ?: [NSNumber numberWithInt:1] intValue];
     datePicker.minuteInterval = minuteInterval;
 
     // Set to something else first, to force an update.
@@ -202,4 +226,3 @@
 }
 
 @end
-

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -122,7 +122,7 @@
 - (void)configureDatePicker:(NSMutableDictionary *)optionsOrNil datePicker:(UIDatePicker *)datePicker;
 {
     long long ticks = [[optionsOrNil objectForKey:@"ticks"] longLongValue];
-    
+
     // Locale
     NSString *localeString = [optionsOrNil objectForKeyNotNull:@"locale"] ?: @"";
     if (localeString.length == 0)
@@ -130,15 +130,15 @@
         localeString = @"EN";
     }
     datePicker.locale = [[NSLocale alloc] initWithLocaleIdentifier:localeString];
-    
+
     // OK
     NSString *okTextString = [optionsOrNil objectForKeyNotNull:@"okText"] ?: @"";
     if (okTextString.length == 0)
     {
-        okTextString = @"Select";
+        okTextString = @"Done";
     }
     self.modalPicker.dismissText = okTextString;
-    
+
     // Cancel
     NSString *cancelTextString = [optionsOrNil objectForKeyNotNull:@"cancelText"] ?: @"";
     if (cancelTextString.length == 0)
@@ -146,11 +146,11 @@
         cancelTextString = @"Cancel";
     }
     self.modalPicker.cancelText = cancelTextString;
-    
+
     // Allow old/future dates
     BOOL allowOldDates = ([[optionsOrNil objectForKeyNotNull:@"allowOldDates"] ?: [NSNumber numberWithInt:1] intValue]) == 1 ? YES : NO;
     BOOL allowFutureDates = ([[optionsOrNil objectForKeyNotNull:@"allowFutureDates"] ?: [NSNumber numberWithInt:1] intValue]) == 1 ? YES : NO;
-    
+
     // Min/max dates
     long long nowTicks = ((long long)[[NSDate date] timeIntervalSince1970]) * DDBIntervalFactor;
     long long minDateTicks = [[optionsOrNil objectForKeyNotNull:@"minDateTicks"] ?: [NSNumber numberWithLong:(allowOldDates ? DDBMinDate : nowTicks)] longLongValue];
@@ -161,7 +161,7 @@
     }
     datePicker.minimumDate = [NSDate dateWithTimeIntervalSince1970:(minDateTicks / DDBIntervalFactor)];
     datePicker.maximumDate = [NSDate dateWithTimeIntervalSince1970:(maxDateTicks / DDBIntervalFactor)];
-    
+
     // Mode
     NSString *mode = [optionsOrNil objectForKey:@"mode"];
     if ([mode isEqualToString:@"date"])
@@ -176,7 +176,7 @@
     {
         datePicker.datePickerMode = UIDatePickerModeDateAndTime;
     }
-    
+
     // Minute interval
     NSInteger minuteInterval = [[optionsOrNil objectForKeyNotNull:@"minuteInterval"] ?: [NSNumber numberWithInt:1] intValue];
     datePicker.minuteInterval = minuteInterval;

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -119,24 +119,6 @@
     self.modalPicker = picker;
 }
 
-- (NSDate *)getRoundedDate:(NSDate *)inDate minuteInterval:(NSInteger)minuteInterval
-{
-    NSDate *truncatedDate = [self truncateSecondsForDate:inDate];
-    NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitMinute fromDate:truncatedDate];
-    NSInteger minutes = [dateComponents minute];
-    NSInteger minutesRounded = ( (NSInteger)(minutes / minuteInterval) ) * minuteInterval;
-    NSDate *roundedDate = [[NSDate alloc] initWithTimeInterval:60.0 * (minutesRounded - minutes) sinceDate:truncatedDate];
-    return roundedDate;
-}
-
-- (NSDate *)truncateSecondsForDate:(NSDate *)fromDate;
-{
-    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-    NSCalendarUnit unitFlags = NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth |  NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute;
-    NSDateComponents *fromDateComponents = [gregorian components:unitFlags fromDate:fromDate ];
-    return [gregorian dateFromComponents:fromDateComponents];
-}
-
 - (void)configureDatePicker:(NSMutableDictionary *)optionsOrNil datePicker:(UIDatePicker *)datePicker;
 {
     long long ticks = [[optionsOrNil objectForKey:@"ticks"] longLongValue];
@@ -201,7 +183,7 @@
 
     // Set to something else first, to force an update.
     datePicker.date = [NSDate dateWithTimeIntervalSince1970:0];
-    datePicker.date = [self getRoundedDate:[[NSDate alloc] initWithTimeIntervalSince1970:(ticks / DDBIntervalFactor)] minuteInterval:minuteInterval];
+    datePicker.date = [[[NSDate alloc] initWithTimeIntervalSince1970:(ticks / DDBIntervalFactor)] roundToMinuteInterval:minuteInterval];
 }
 
 // Sends the date to the plugin javascript handler.

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -132,7 +132,7 @@
     }
     else
     {
-        datePicker.locale = [NSLocale systemLocale];
+        datePicker.locale = [NSLocale currentLocale];
     }
     
     // Texts

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -153,8 +153,8 @@
     NSDate *today = [NSDate today];
     long long todayTicks = ((long long)[today timeIntervalSince1970]) * DDBIntervalFactor;
     long long endOfTodayTicks = ((long long)[[[today addDay:1] addSecond:-1] timeIntervalSince1970]) * DDBIntervalFactor;
-    long long minDateTicks = [[optionsOrNil objectForKeyNotNull:@"minDateTicks"] ?: [NSNumber numberWithLong:(allowOldDates ? DDBMinDate : todayTicks)] longLongValue];
-    long long maxDateTicks = [[optionsOrNil objectForKeyNotNull:@"maxDateTicks"] ?: [NSNumber numberWithLong:(allowFutureDates ? DDBMaxDate : endOfTodayTicks)] longLongValue];
+    long long minDateTicks = [[optionsOrNil objectForKeyNotNull:@"minDateTicks"] ?: [NSNumber numberWithLongLong:(allowOldDates ? DDBMinDate : todayTicks)] longLongValue];
+    long long maxDateTicks = [[optionsOrNil objectForKeyNotNull:@"maxDateTicks"] ?: [NSNumber numberWithLongLong:(allowFutureDates ? DDBMaxDate : endOfTodayTicks)] longLongValue];
     if (minDateTicks > maxDateTicks)
     {
         minDateTicks = DDBMinDate;

--- a/src/ios/Extensions.h
+++ b/src/ios/Extensions.h
@@ -1,0 +1,3 @@
+@interface NSDictionary (NSDictionaryAdditions)
+- (id)objectForKeyNotNull:(NSString*)key;
+@end

--- a/src/ios/Extensions.h
+++ b/src/ios/Extensions.h
@@ -1,3 +1,8 @@
 @interface NSDictionary (NSDictionaryAdditions)
 - (id)objectForKeyNotNull:(NSString*)key;
 @end
+
+@interface NSDate (NSDateAdditions)
+- (NSDate *)truncateSeconds;
+- (NSDate *)roundToMinuteInterval:(NSInteger)minuteInterval;
+@end

--- a/src/ios/Extensions.h
+++ b/src/ios/Extensions.h
@@ -5,4 +5,9 @@
 @interface NSDate (NSDateAdditions)
 - (NSDate *)truncateSeconds;
 - (NSDate *)roundToMinuteInterval:(NSInteger)minuteInterval;
+- (NSDate *)roundDownToMinuteInterval:(NSInteger)minuteInterval;
+- (NSDate *)roundUpToMinuteInterval:(NSInteger)minuteInterval;
++ (NSDate *)today;
+- (NSDate *)addDay:(NSInteger)day;
+- (NSDate *)addSecond:(NSInteger)second;
 @end

--- a/src/ios/Extensions.h
+++ b/src/ios/Extensions.h
@@ -2,6 +2,10 @@
 - (id)objectForKeyNotNull:(NSString*)key;
 @end
 
+@interface UIColor (UIColorAdditions)
++ (UIColor *)colorWithR:(CGFloat)red G:(CGFloat)green B:(CGFloat)blue A:(CGFloat)alpha;
+@end
+
 @interface NSDate (NSDateAdditions)
 - (NSDate *)truncateSeconds;
 - (NSDate *)roundToMinuteInterval:(NSInteger)minuteInterval;
@@ -10,4 +14,8 @@
 + (NSDate *)today;
 - (NSDate *)addDay:(NSInteger)day;
 - (NSDate *)addSecond:(NSInteger)second;
+@end
+
+@interface UIBarButtonItem (UIBarButtonItemAdditions)
+- (void) setFont:(UIFont *)font highlightedFont:(UIFont *)highlightedFont;
 @end

--- a/src/ios/Extensions.m
+++ b/src/ios/Extensions.m
@@ -17,10 +17,10 @@
 
 - (NSDate *)truncateSeconds
 {
-    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    NSCalendar *calendar = [NSCalendar currentCalendar];
     NSCalendarUnit unitFlags = NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth |  NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute;
-    NSDateComponents *fromDateComponents = [gregorian components:unitFlags fromDate:self];
-    return [gregorian dateFromComponents:fromDateComponents];
+    NSDateComponents *dateComponents = [calendar components:unitFlags fromDate:self];
+    return [calendar dateFromComponents:dateComponents];
 }
 
 - (NSDate *)roundToMinuteInterval:(NSInteger)minuteInterval
@@ -28,9 +28,53 @@
     NSDate *truncatedDate = [self truncateSeconds];
     NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitMinute fromDate:truncatedDate];
     NSInteger minutes = [dateComponents minute];
-    NSInteger minutesRounded = ( (NSInteger)(minutes / minuteInterval) ) * minuteInterval;
+    NSInteger minutesRounded = (NSInteger)( roundf( (float)(minutes / minuteInterval) ) ) * minuteInterval;
     NSDate *roundedDate = [[NSDate alloc] initWithTimeInterval:60.0 * (minutesRounded - minutes) sinceDate:truncatedDate];
     return roundedDate;
+}
+
+- (NSDate *)roundDownToMinuteInterval:(NSInteger)minuteInterval
+{
+    NSDate *truncatedDate = [self truncateSeconds];
+    NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitMinute fromDate:truncatedDate];
+    NSInteger minutes = [dateComponents minute];
+    NSInteger minutesRounded = (NSInteger)( floor( (float)(minutes / minuteInterval) ) ) * minuteInterval;
+    NSDate *roundedDate = [[NSDate alloc] initWithTimeInterval:60.0 * (minutesRounded - minutes) sinceDate:truncatedDate];
+    return roundedDate;
+}
+
+- (NSDate *)roundUpToMinuteInterval:(NSInteger)minuteInterval
+{
+    NSDate *truncatedDate = [self truncateSeconds];
+    NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitMinute fromDate:truncatedDate];
+    NSInteger minutes = [dateComponents minute];
+    NSInteger minutesRounded = (NSInteger)( ceil( (float)(minutes / minuteInterval) ) ) * minuteInterval;
+    NSDate *roundedDate = [[NSDate alloc] initWithTimeInterval:60.0 * (minutesRounded - minutes) sinceDate:truncatedDate];
+    return roundedDate;
+}
+
++ (NSDate *)today
+{
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    NSCalendarUnit unitFlags = NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth |  NSCalendarUnitDay;
+    NSDateComponents *dateComponents = [calendar components:unitFlags fromDate:[NSDate date]];
+    return [calendar dateFromComponents:dateComponents];
+}
+
+- (NSDate *)addDay:(NSInteger)day
+{
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
+    dayComponent.day = day;
+    return [calendar dateByAddingComponents:dayComponent toDate:self options:0];
+}
+
+- (NSDate *)addSecond:(NSInteger)second
+{
+    NSCalendar *calendar = [NSCalendar currentCalendar];
+    NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
+    dayComponent.second = second;
+    return [calendar dateByAddingComponents:dayComponent toDate:self options:0];
 }
 
 @end

--- a/src/ios/Extensions.m
+++ b/src/ios/Extensions.m
@@ -2,8 +2,7 @@
 
 @implementation NSDictionary (NSDictionaryAdditions)
 
-- (id)objectForKeyNotNull:(NSString*)key
-{
+- (id)objectForKeyNotNull:(NSString*)key {
     id object = [self objectForKey:key];
     if (object == [NSNull null])
         return nil;
@@ -13,18 +12,24 @@
 
 @end
 
+@implementation UIColor (UIColorAdditions)
+
++ (UIColor *)colorWithR:(CGFloat)red G:(CGFloat)green B:(CGFloat)blue A:(CGFloat)alpha {
+    return [UIColor colorWithRed:(red/255.0) green:(green/255.0) blue:(blue/255.0) alpha:alpha];
+}
+
+@end
+
 @implementation NSDate (NSDateAdditions)
 
-- (NSDate *)truncateSeconds
-{
+- (NSDate *)truncateSeconds {
     NSCalendar *calendar = [NSCalendar currentCalendar];
     NSCalendarUnit unitFlags = NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth |  NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute;
     NSDateComponents *dateComponents = [calendar components:unitFlags fromDate:self];
     return [calendar dateFromComponents:dateComponents];
 }
 
-- (NSDate *)roundToMinuteInterval:(NSInteger)minuteInterval
-{
+- (NSDate *)roundToMinuteInterval:(NSInteger)minuteInterval {
     NSDate *truncatedDate = [self truncateSeconds];
     NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitMinute fromDate:truncatedDate];
     NSInteger minutes = [dateComponents minute];
@@ -33,8 +38,7 @@
     return roundedDate;
 }
 
-- (NSDate *)roundDownToMinuteInterval:(NSInteger)minuteInterval
-{
+- (NSDate *)roundDownToMinuteInterval:(NSInteger)minuteInterval {
     NSDate *truncatedDate = [self truncateSeconds];
     NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitMinute fromDate:truncatedDate];
     NSInteger minutes = [dateComponents minute];
@@ -43,8 +47,7 @@
     return roundedDate;
 }
 
-- (NSDate *)roundUpToMinuteInterval:(NSInteger)minuteInterval
-{
+- (NSDate *)roundUpToMinuteInterval:(NSInteger)minuteInterval {
     NSDate *truncatedDate = [self truncateSeconds];
     NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitMinute fromDate:truncatedDate];
     NSInteger minutes = [dateComponents minute];
@@ -53,28 +56,38 @@
     return roundedDate;
 }
 
-+ (NSDate *)today
-{
++ (NSDate *)today {
     NSCalendar *calendar = [NSCalendar currentCalendar];
     NSCalendarUnit unitFlags = NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth |  NSCalendarUnitDay;
     NSDateComponents *dateComponents = [calendar components:unitFlags fromDate:[NSDate date]];
     return [calendar dateFromComponents:dateComponents];
 }
 
-- (NSDate *)addDay:(NSInteger)day
-{
+- (NSDate *)addDay:(NSInteger)day {
     NSCalendar *calendar = [NSCalendar currentCalendar];
     NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
     dayComponent.day = day;
     return [calendar dateByAddingComponents:dayComponent toDate:self options:0];
 }
 
-- (NSDate *)addSecond:(NSInteger)second
-{
+- (NSDate *)addSecond:(NSInteger)second {
     NSCalendar *calendar = [NSCalendar currentCalendar];
     NSDateComponents *dayComponent = [[NSDateComponents alloc] init];
     dayComponent.second = second;
     return [calendar dateByAddingComponents:dayComponent toDate:self options:0];
+}
+
+@end
+
+@implementation UIBarButtonItem (UIBarButtonItemAdditions)
+
+- (void) setFont:(UIFont *)font highlightedFont:(UIFont *)highlightedFont {
+    NSDictionary *buttonFontAppearance = [NSDictionary dictionaryWithObjectsAndKeys:font, NSFontAttributeName, nil];
+    NSDictionary *buttonHighlightedFontAppearance = [NSDictionary dictionaryWithObjectsAndKeys:highlightedFont, NSFontAttributeName, nil];
+    [self setTitleTextAttributes:buttonFontAppearance forState:UIControlStateNormal];
+    [self setTitleTextAttributes:buttonHighlightedFontAppearance forState:UIControlStateHighlighted];
+    [self setTitleTextAttributes:buttonFontAppearance forState:UIControlStateFocused];
+    [self setTitleTextAttributes:buttonFontAppearance forState:UIControlStateDisabled];
 }
 
 @end

--- a/src/ios/Extensions.m
+++ b/src/ios/Extensions.m
@@ -12,3 +12,25 @@
 }
 
 @end
+
+@implementation NSDate (NSDateAdditions)
+
+- (NSDate *)truncateSeconds
+{
+    NSCalendar *gregorian = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+    NSCalendarUnit unitFlags = NSCalendarUnitEra | NSCalendarUnitYear | NSCalendarUnitMonth |  NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute;
+    NSDateComponents *fromDateComponents = [gregorian components:unitFlags fromDate:self];
+    return [gregorian dateFromComponents:fromDateComponents];
+}
+
+- (NSDate *)roundToMinuteInterval:(NSInteger)minuteInterval
+{
+    NSDate *truncatedDate = [self truncateSeconds];
+    NSDateComponents *dateComponents = [[NSCalendar currentCalendar] components:NSCalendarUnitMinute fromDate:truncatedDate];
+    NSInteger minutes = [dateComponents minute];
+    NSInteger minutesRounded = ( (NSInteger)(minutes / minuteInterval) ) * minuteInterval;
+    NSDate *roundedDate = [[NSDate alloc] initWithTimeInterval:60.0 * (minutesRounded - minutes) sinceDate:truncatedDate];
+    return roundedDate;
+}
+
+@end

--- a/src/ios/Extensions.m
+++ b/src/ios/Extensions.m
@@ -1,0 +1,14 @@
+#import "Extensions.h"
+
+@implementation NSDictionary (NSDictionaryAdditions)
+
+- (id)objectForKeyNotNull:(NSString*)key
+{
+    id object = [self objectForKey:key];
+    if (object == [NSNull null])
+        return nil;
+    else
+        return object;
+}
+
+@end

--- a/src/ios/ModalPickerViewController.h
+++ b/src/ios/ModalPickerViewController.h
@@ -1,17 +1,16 @@
 #import <UIKit/UIKit.h>
 
-@interface ModalPickerViewController : UIViewController
-{
+@interface ModalPickerViewController : UIViewController {
 }
 
 - (id)init;
 
 @property (strong) NSString *titleText;
-@property (strong) NSString *dismissText;
+@property (strong) NSString *doneText;
 @property (strong) NSString *cancelText;
 @property (strong) NSString *clearText;
 @property (strong) UIDatePicker *datePicker;
-@property (nonatomic, strong) void (^dismissedHandler)(id sender);
+@property (nonatomic, strong) void (^doneHandler)(id sender);
 @property (nonatomic, strong) void (^cancelHandler)();
 
 @end

--- a/src/ios/ModalPickerViewController.h
+++ b/src/ios/ModalPickerViewController.h
@@ -4,17 +4,14 @@
 {
 }
 
-- (id)initWithHeaderText:(NSString*)headerText
-             dismissText:(NSString*)dismissText
-             cancelText:(NSString*)cancelText;
+- (id)init;
 
-@property (strong) UIColor *headerBackgroundColor;
-@property (strong) UIColor *headerTextColor;
-@property (strong) NSString *headerText;
+@property (strong) NSString *titleText;
 @property (strong) NSString *dismissText;
 @property (strong) NSString *cancelText;
+@property (strong) NSString *clearText;
 @property (strong) UIDatePicker *datePicker;
 @property (nonatomic, strong) void (^dismissedHandler)(id sender);
-@property (nonatomic, strong) void (^cancelHandler)(id sender);
+@property (nonatomic, strong) void (^cancelHandler)();
 
 @end

--- a/src/ios/ModalPickerViewController.m
+++ b/src/ios/ModalPickerViewController.m
@@ -2,57 +2,45 @@
 
 @interface ModalPickerViewController()
 
-@property (strong) UILabel* headerLabel;
-@property (strong) UIButton *doneButton;
-@property (strong) UIButton *cancelButton;
 @property (strong) UIView *internalView;
+
+@property (strong) UIBarButtonItem *doneButton;
+@property (strong) UIBarButtonItem *clearButton;
+@property (strong) UIBarButtonItem *cancelButton;
 
 @end
 
 @implementation ModalPickerViewController
 
 
-const float _headerBarHeight = 38;
+const float _headerBarHeight = 42;
 const float _datePickerHeight = 200;
 
-const CGSize _doneButtonSize = { 80, 30 };
-const CGSize _cancelButtonSize = { 80, 30 };
-const float _buttonMargin = 10;
-
-
-- (id)initWithHeaderText:(NSString*)headerText
-             dismissText:(NSString*)dismissText
-             cancelText:(NSString*)cancelText {
-    self.headerBackgroundColor = [UIColor whiteColor];
-    self.headerTextColor = [UIColor blackColor];
-    self.headerText = headerText;
-    self.dismissText = dismissText;
-    self.cancelText = cancelText;
-
-    [self createControls];
+- (id)init
+{
+    self.view.backgroundColor = [UIColor clearColor];
+    self.view.opaque = NO;
+    
+    _datePicker = [[UIDatePicker alloc] initWithFrame:CGRectZero];
 
     return self;
-}
-
-- (void)viewDidLoad {
-    [super viewDidLoad];
-    // Do any additional setup after loading the view.
-}
-
-- (void)didReceiveMemoryWarning {
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 
-    _internalView.backgroundColor = _headerBackgroundColor;
-    _headerLabel.textColor = _headerTextColor;
-    _headerLabel.text = _headerText;
+    [self createControls];
+}
 
-    [_doneButton setTitle:_dismissText forState:UIControlStateNormal];
-    [_cancelButton setTitle:_cancelText forState:UIControlStateNormal];
+- (void)viewDidDisappear:(BOOL)animated {
+    [super viewDidDisappear:animated];
+    
+    [_internalView removeFromSuperview];
+    _internalView = nil;
+
+    _doneButton = nil;
+    _clearButton = nil;
+    _cancelButton = nil;
 }
 
 - (BOOL)shouldAutorotate {
@@ -64,54 +52,60 @@ const float _buttonMargin = 10;
 }
 
 - (void)createControls {
-    self.view.backgroundColor = [UIColor clearColor];
-    self.view.opaque = NO;
 
     // Measurements of our internal view.
     CGRect viewFrame = self.view.frame;
-    CGSize internalViewSize = CGSizeMake(viewFrame.size.width, _datePickerHeight + _headerBarHeight);
+    CGSize internalViewSize = CGSizeMake(viewFrame.size.width, _datePickerHeight + _headerBarHeight + 4);
     CGRect internalViewFrame = CGRectMake(0, viewFrame.size.height - internalViewSize.height, internalViewSize.width, internalViewSize.height);
-
-    // Create header label.
-    float labelWidth = internalViewSize.width - _doneButtonSize.width - _cancelButtonSize.width - _buttonMargin * 2;
-    _headerLabel = [[UILabel alloc] initWithFrame:CGRectMake((internalViewSize.width - labelWidth) / 2, 0, labelWidth, _headerBarHeight)];
-    _headerLabel.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-   // _headerLabel.backgroundColor = self.headerBackgroundColor;
-    _headerLabel.adjustsFontSizeToFitWidth = NO;
-    _headerLabel.textAlignment = NSTextAlignmentCenter;
-    _headerLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-
-    // Create done button.
-    _doneButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    _doneButton.frame = CGRectMake(internalViewFrame.size.width - _doneButtonSize.width - _buttonMargin, _buttonMargin / 2, _doneButtonSize.width, _doneButtonSize.height);
-    _doneButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleBottomMargin;
-    _doneButton.backgroundColor = [UIColor clearColor];
-    _doneButton.titleLabel.font = [UIFont boldSystemFontOfSize:[UIFont systemFontSize] * 1.1];
-    [_doneButton addTarget:self action:@selector(doneButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
-
-    // Create cancel button.
-    _cancelButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    _cancelButton.frame = CGRectMake(_buttonMargin, _buttonMargin / 2, _cancelButtonSize.width, _cancelButtonSize.height);
-    _cancelButton.autoresizingMask = UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleBottomMargin;
-    _cancelButton.backgroundColor = [UIColor clearColor];
-    _cancelButton.titleLabel.font = [UIFont systemFontOfSize:[UIFont systemFontSize] * 1.1];
-    [_cancelButton addTarget:self action:@selector(cancelButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
-
-    // Create the date picker.
-    _datePicker = [[UIDatePicker alloc] initWithFrame:CGRectZero];
-    _datePicker.frame = CGRectMake(0, _headerBarHeight, internalViewSize.width, _datePickerHeight);
-    _datePicker.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
-    _datePicker.backgroundColor = [UIColor colorWithWhite:1 alpha:0.85f];
 
     // Create a view that will host our controls.
     _internalView = [[UIView alloc] init];
     _internalView.frame = internalViewFrame;
     _internalView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
+    _internalView.backgroundColor = [UIColor colorWithWhite:1 alpha:.85f];
+    _internalView.opaque = FALSE;
+    
+    CGRect navBarFrame = CGRectMake(0, 1, viewFrame.size.width, _headerBarHeight);
+    UINavigationBar *navigationBar = [[UINavigationBar alloc] initWithFrame:navBarFrame];
+    navigationBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    navigationBar.backgroundColor = [UIColor grayColor];
+    navigationBar.translucent = YES;
+    
+    // Navigation item
+    UINavigationItem *navItem = [[UINavigationItem alloc] initWithTitle:_titleText];
+    [navigationBar setItems:@[navItem]];
+    
+    // Right buttons
+    if (_dismissText != (id)[NSNull null] && _dismissText.length > 0) {
+        _doneButton = [[UIBarButtonItem alloc] initWithTitle:_dismissText style:UIBarButtonItemStyleDone target:self action:@selector(doneButtonTapped:)];
+    }
+    else {
+        _doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneButtonTapped:)];
+    }
+    [navItem setRightBarButtonItem:_doneButton animated:NO];
+    
+    if (_clearText != (id)[NSNull null] && _clearText.length > 0) {
+        _clearButton = [[UIBarButtonItem alloc] initWithTitle:_clearText style:UIBarButtonItemStylePlain target:self action:@selector(clearButtonTapped:)];
+        [navItem setRightBarButtonItems:@[_doneButton, _clearButton] animated:NO];
+    }
+    
+    // Left button
+    if (_cancelText != (id)[NSNull null] && _cancelText.length > 0) {
+        _cancelButton = [[UIBarButtonItem alloc] initWithTitle:_cancelText style:UIBarButtonItemStylePlain target:self action:@selector(cancelButtonTapped:)];
+    }
+    else {
+        _cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonTapped:)];
+    }
+    [navItem setLeftBarButtonItem:_cancelButton animated:NO];
+    
+    // Set the date picker.
+    _datePicker.autoresizingMask = UIViewAutoresizingNone;
+    _datePicker.frame = CGRectMake(0, navigationBar.frame.origin.y + navigationBar.frame.size.height + 3, internalViewSize.width, _datePickerHeight);
+    _datePicker.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
+    _datePicker.backgroundColor = [UIColor whiteColor];
 
     [_internalView addSubview:_datePicker];
-    [_internalView addSubview:_headerLabel];
-    [_internalView addSubview:_doneButton];
-    [_internalView addSubview:_cancelButton];
+    [_internalView addSubview:navigationBar];
 
     [self.view addSubview:_internalView];
 }
@@ -119,16 +113,24 @@ const float _buttonMargin = 10;
 
 #pragma mark - Button handlers
 
-- (IBAction)doneButtonTapped:(id)sender {
-    [self dismissViewControllerAnimated:true completion:nil];
-    // Call the callback.
-    if (self.dismissedHandler != nil) [self dismissedHandler](self);
+- (void)doneButtonTapped:(UIBarButtonItem*)sender {
+    [self dismissViewControllerAnimated:true completion:^(void) {
+        // Call the callback.
+        if (self.dismissedHandler != nil) [self dismissedHandler](self);
+    }];
 }
 
-- (IBAction)cancelButtonTapped:(id)sender {
-    [self dismissViewControllerAnimated:true completion:nil];
-    // Call the callback.
-    if (self.cancelHandler != nil) [self cancelHandler](self);
+- (void)cancelButtonTapped:(UIBarButtonItem*)sender {
+    [self dismissViewControllerAnimated:true completion:^(void) {
+        // Call the callback.
+        if (self.cancelHandler != nil) [self cancelHandler]();
+    }];
 }
 
+- (void)clearButtonTapped:(UIBarButtonItem*)sender {
+    [self dismissViewControllerAnimated:true completion:^(void) {
+        // Call the callback.
+        if (self.dismissedHandler != nil) [self dismissedHandler](nil);
+    }];
+}
 @end

--- a/src/ios/ModalPickerViewController.m
+++ b/src/ios/ModalPickerViewController.m
@@ -1,46 +1,101 @@
 #import "ModalPickerViewController.h"
+#import "Extensions.h"
+
+static const float kHeaderBarHeight = 44;
+static const float kHeaderBarHeightSmall = 32;
+static const float kDatePickerHeight = 200;
 
 @interface ModalPickerViewController()
 
-@property (strong) UIView *internalView;
-
-@property (strong) UIBarButtonItem *doneButton;
-@property (strong) UIBarButtonItem *clearButton;
-@property (strong) UIBarButtonItem *cancelButton;
-
 @end
 
-@implementation ModalPickerViewController
+@implementation ModalPickerViewController {
+    UIView *_internalView;
 
+    UINavigationBar *_navigationBar;
+    UINavigationItem *_navigationItem;
 
-const float _headerBarHeight = 42;
-const float _datePickerHeight = 200;
+    UIBarButtonItem *_doneButton;
+    UIBarButtonItem *_clearButton;
+    UIBarButtonItem *_cancelButton;
 
-- (id)init
-{
+    NSLayoutConstraint *_navBarHeight;
+    
+    UIColor *lightBackgroundColor;
+    UIColor *lightDatePickerBackgroundColor;
+    UIColor *lightButtonLabelColor;
+    UIColor *darkBackgroundColor;
+    UIColor *darkDatePickerBackgroundColor;
+    UIColor *darkButtonLabelColor;
+}
+
+- (id)init {
+    if ((self = [super init])) {
+        _datePicker = [[UIDatePicker alloc] init];
+    }
+
+    return self;
+}
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    
     self.view.backgroundColor = [UIColor clearColor];
     self.view.opaque = NO;
     
-    _datePicker = [[UIDatePicker alloc] initWithFrame:CGRectZero];
+    [self createSwatches];
+    [self createControls];
+}
 
-    return self;
+- (void)didReceiveMemoryWarning {
+    if (!(self.isViewLoaded && self.view.window)) {
+        [_navigationBar removeFromSuperview];
+        [_internalView removeFromSuperview];
+        [_datePicker removeFromSuperview];
+        // Do NOT reset datepicker ref.
+        _navigationBar = nil;
+        _navigationItem = nil;
+        _internalView = nil;
+    
+        _doneButton = nil;
+        _clearButton = nil;
+        _cancelButton = nil;
+        
+        lightBackgroundColor = nil;
+        darkBackgroundColor = nil;
+        lightDatePickerBackgroundColor = nil;
+        darkDatePickerBackgroundColor = nil;
+        lightButtonLabelColor = nil;
+        darkButtonLabelColor = nil;
+        
+        _navBarHeight = nil;
+    }
+    
+    [super didReceiveMemoryWarning];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
 
-    [self createControls];
-}
-
-- (void)viewDidDisappear:(BOOL)animated {
-    [super viewDidDisappear:animated];
+    if (!_internalView) {
+        [self createSwatches];
+        [self createControls];
+    }
     
-    [_internalView removeFromSuperview];
-    _internalView = nil;
+    // Update texts.
+    _navigationItem.title = _titleText;
 
-    _doneButton = nil;
-    _clearButton = nil;
-    _cancelButton = nil;
+    _doneButton.title = _doneText != (id)[NSNull null] && _doneText.length > 0 ? _doneText : UIKitLocalizedString(@"Done");
+    _cancelButton.title = _cancelText != (id)[NSNull null] && _cancelText.length > 0 ? _cancelText : UIKitLocalizedString(@"Cancel");
+    
+    // Show clear button when clear text is set
+    if (_clearText != (id)[NSNull null] && _clearText.length > 0) {
+        _clearButton.title = _clearText;
+        [_navigationItem setRightBarButtonItems:@[_doneButton, _clearButton] animated:NO];
+    } else {
+        _clearButton.title = nil;
+        [_navigationItem setRightBarButtonItems:@[_doneButton] animated:NO];
+    }
 }
 
 - (BOOL)shouldAutorotate {
@@ -51,72 +106,138 @@ const float _datePickerHeight = 200;
     return UIInterfaceOrientationMaskAll;
 }
 
-- (void)createControls {
-
-    // Measurements of our internal view.
-    CGRect viewFrame = self.view.frame;
-    CGSize internalViewSize = CGSizeMake(viewFrame.size.width, _datePickerHeight + _headerBarHeight + 4);
-    CGRect internalViewFrame = CGRectMake(0, viewFrame.size.height - internalViewSize.height, internalViewSize.width, internalViewSize.height);
-
-    // Create a view that will host our controls.
-    _internalView = [[UIView alloc] init];
-    _internalView.frame = internalViewFrame;
-    _internalView.autoresizingMask = UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleWidth;
-    _internalView.backgroundColor = [UIColor colorWithWhite:1 alpha:.85f];
-    _internalView.opaque = FALSE;
-    
-    CGRect navBarFrame = CGRectMake(0, 1, viewFrame.size.width, _headerBarHeight);
-    UINavigationBar *navigationBar = [[UINavigationBar alloc] initWithFrame:navBarFrame];
-    navigationBar.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-    navigationBar.backgroundColor = [UIColor grayColor];
-    navigationBar.translucent = YES;
-    
-    // Navigation item
-    UINavigationItem *navItem = [[UINavigationItem alloc] initWithTitle:_titleText];
-    [navigationBar setItems:@[navItem]];
-    
-    // Right buttons
-    if (_dismissText != (id)[NSNull null] && _dismissText.length > 0) {
-        _doneButton = [[UIBarButtonItem alloc] initWithTitle:_dismissText style:UIBarButtonItemStyleDone target:self action:@selector(doneButtonTapped:)];
-    }
-    else {
-        _doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self action:@selector(doneButtonTapped:)];
-    }
-    [navItem setRightBarButtonItem:_doneButton animated:NO];
-    
-    if (_clearText != (id)[NSNull null] && _clearText.length > 0) {
-        _clearButton = [[UIBarButtonItem alloc] initWithTitle:_clearText style:UIBarButtonItemStylePlain target:self action:@selector(clearButtonTapped:)];
-        [navItem setRightBarButtonItems:@[_doneButton, _clearButton] animated:NO];
-    }
-    
-    // Left button
-    if (_cancelText != (id)[NSNull null] && _cancelText.length > 0) {
-        _cancelButton = [[UIBarButtonItem alloc] initWithTitle:_cancelText style:UIBarButtonItemStylePlain target:self action:@selector(cancelButtonTapped:)];
-    }
-    else {
-        _cancelButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemCancel target:self action:@selector(cancelButtonTapped:)];
-    }
-    [navItem setLeftBarButtonItem:_cancelButton animated:NO];
-    
-    // Set the date picker.
-    _datePicker.autoresizingMask = UIViewAutoresizingNone;
-    _datePicker.frame = CGRectMake(0, navigationBar.frame.origin.y + navigationBar.frame.size.height + 3, internalViewSize.width, _datePickerHeight);
-    _datePicker.autoresizingMask = UIViewAutoresizingFlexibleBottomMargin | UIViewAutoresizingFlexibleWidth;
-    _datePicker.backgroundColor = [UIColor whiteColor];
-
-    [_internalView addSubview:_datePicker];
-    [_internalView addSubview:navigationBar];
-
-    [self.view addSubview:_internalView];
+- (void)viewWillLayoutSubviews {
+    [self updateStyles];
+    [super viewWillLayoutSubviews];
 }
 
+- (void)traitCollectionDidChange: (UITraitCollection *) previousTraitCollection {
+    [self updateStyles];
+    [super traitCollectionDidChange: previousTraitCollection];
+}
+
+#pragma mark - Controls/styling
+
+- (void)createControls {
+    // Create a view that will host our controls.
+    _internalView = [[UIView alloc] init];
+    _internalView.opaque = FALSE;
+    
+    // Nav bar
+    _navigationBar = [[UINavigationBar alloc] init];
+    _navigationBar.translucent = TRUE;
+    _navigationBar.opaque = FALSE;
+    
+    _navigationItem = [[UINavigationItem alloc] init];
+    [_navigationBar setItems:@[_navigationItem]];
+
+    // Right buttons
+    _doneButton = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStyleDone target:self action:@selector(doneButtonTapped:)];
+    [_navigationItem setRightBarButtonItem:_doneButton animated:NO];
+
+    _clearButton = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:self action:@selector(clearButtonTapped:)];
+    
+    // Left button
+    _cancelButton = [[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:self action:@selector(cancelButtonTapped:)];
+    [_navigationItem setLeftBarButtonItem:_cancelButton animated:NO];
+
+    // Custom hairline above header.
+    addHairLine(_internalView.layer, CGSizeMake(0, -1));
+
+    // Add to view
+    [_internalView addSubview:_datePicker];
+    [_internalView addSubview:_navigationBar];
+    [self.view addSubview:_internalView];
+
+    // Set constraints.
+    _internalView.translatesAutoresizingMaskIntoConstraints = FALSE;
+    _datePicker.translatesAutoresizingMaskIntoConstraints = FALSE;
+    _navigationBar.translatesAutoresizingMaskIntoConstraints = FALSE;
+        
+    NSLayoutConstraint *viewWidth = [NSLayoutConstraint constraintWithItem:_internalView attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeWidth multiplier:1 constant:0];
+    NSLayoutConstraint *viewHeight = [NSLayoutConstraint constraintWithItem:_internalView attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeNotAnAttribute multiplier:1 constant:kHeaderBarHeight + kDatePickerHeight];
+    NSLayoutConstraint *viewBottom = [NSLayoutConstraint constraintWithItem:_internalView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self.view attribute:NSLayoutAttributeBottom multiplier:1 constant:0];
+
+    NSLayoutConstraint *navBarTop = [NSLayoutConstraint constraintWithItem:_navigationBar attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:_internalView attribute:NSLayoutAttributeTop multiplier:1 constant:0];
+    NSLayoutConstraint *navBarWidth = [NSLayoutConstraint constraintWithItem:_navigationBar attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:_internalView attribute:NSLayoutAttributeWidth multiplier:1 constant:0];
+    _navBarHeight = [NSLayoutConstraint constraintWithItem:_navigationBar attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:NSLayoutAttributeHeight multiplier:1 constant:kHeaderBarHeightSmall];
+
+    NSLayoutConstraint *datePickerTop = [NSLayoutConstraint constraintWithItem:_datePicker attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:_navigationBar attribute:NSLayoutAttributeBottom multiplier:1 constant:0];
+    NSLayoutConstraint *datePickerBottom = [NSLayoutConstraint constraintWithItem:_datePicker attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:_internalView attribute:NSLayoutAttributeBottom multiplier:1 constant:0];
+    NSLayoutConstraint *datePickerWidth = [NSLayoutConstraint constraintWithItem:_datePicker attribute:NSLayoutAttributeWidth relatedBy:NSLayoutRelationEqual toItem:_internalView attribute:NSLayoutAttributeWidth multiplier:1 constant:0];
+
+    [NSLayoutConstraint activateConstraints:@[
+        viewWidth, viewBottom, viewHeight,
+        navBarTop, navBarWidth, _navBarHeight,
+        datePickerTop, datePickerBottom, datePickerWidth
+    ]];
+}
+
+- (void)createSwatches {
+    lightBackgroundColor = [UIColor colorWithR:240 G:240 B:240 A:1];
+    darkBackgroundColor = [UIColor colorWithR:67 G:67 B:67 A:1];
+    lightDatePickerBackgroundColor = [UIColor colorWithR:209 G:212 B:217 A:1];
+    darkDatePickerBackgroundColor = [UIColor colorWithR:87 G:87 B:87 A:1];
+    if (@available(iOS 13, *)) {
+        lightButtonLabelColor = [UIColor linkColor];
+        darkButtonLabelColor = [UIColor labelColor];
+    } else {
+        lightButtonLabelColor = [UIColor systemBlueColor];
+        darkButtonLabelColor = [UIColor whiteColor];
+    }
+}
+
+- (void)updateStyles {
+    // System font may have changed.
+    CGFloat buttonFontSize = [UIFont systemFontSize] * 1.05;
+    CGFloat largeButtonFontSize = buttonFontSize * 1.15;
+    [_doneButton setFont:[UIFont boldSystemFontOfSize:buttonFontSize] highlightedFont:[UIFont boldSystemFontOfSize:largeButtonFontSize]];
+    [_clearButton setFont:[UIFont systemFontOfSize:buttonFontSize] highlightedFont:[UIFont systemFontOfSize:largeButtonFontSize]];
+    [_cancelButton setFont:[UIFont systemFontOfSize:buttonFontSize] highlightedFont:[UIFont systemFontOfSize:largeButtonFontSize]];
+
+    // Switch between large/small navbar height depending on orientation.
+    BOOL isPortrait = self.view.bounds.size.width < self.view.bounds.size.height;
+    _navBarHeight.constant = isPortrait ? kHeaderBarHeight : kHeaderBarHeightSmall;
+
+    // Switching light/dark mode.
+    UIColor *backgroundColor = lightBackgroundColor;
+    UIColor *datePickerBackgroundColor = lightDatePickerBackgroundColor;
+    UIColor *buttonLabelColor = lightButtonLabelColor;
+
+    if (@available(iOS 12, *)) {
+        BOOL isDarkMode = self.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark;
+        if (isDarkMode) {
+            backgroundColor = darkBackgroundColor;
+            datePickerBackgroundColor = darkDatePickerBackgroundColor;
+            buttonLabelColor = darkButtonLabelColor;
+        }
+    }
+
+    _internalView.backgroundColor = backgroundColor;
+    _navigationBar.tintColor = buttonLabelColor;
+    _datePicker.backgroundColor = datePickerBackgroundColor;
+}
+
+#pragma mark - Utils
+
+NSString *UIKitLocalizedString(NSString *key) {
+    return [[NSBundle bundleForClass:UIApplication.class] localizedStringForKey:key value:nil table:nil];
+}
+
+void addHairLine(CALayer *layer, CGSize shadowOffset) {
+//    CGSize scaledOffset = CGSizeMake(shadowOffset.width / UIScreen.mainScreen.scale, shadowOffset.height / UIScreen.mainScreen.scale);
+    layer.shadowOffset = shadowOffset;
+    layer.shadowRadius = 0;
+    layer.shadowColor = [[UIColor colorWithR:128 G:128 B:128 A:1] CGColor];
+    layer.shadowOpacity = 0.3f;
+}
 
 #pragma mark - Button handlers
 
 - (void)doneButtonTapped:(UIBarButtonItem*)sender {
     [self dismissViewControllerAnimated:true completion:^(void) {
         // Call the callback.
-        if (self.dismissedHandler != nil) [self dismissedHandler](self);
+        if (self.doneHandler != nil) [self doneHandler](self);
     }];
 }
 
@@ -130,7 +251,7 @@ const float _datePickerHeight = 200;
 - (void)clearButtonTapped:(UIBarButtonItem*)sender {
     [self dismissViewControllerAnimated:true completion:^(void) {
         // Call the callback.
-        if (self.dismissedHandler != nil) [self dismissedHandler](nil);
+        if (self.doneHandler != nil) [self doneHandler](nil);
     }];
 }
 @end

--- a/src/ios/TransparentCoverVerticalAnimator.m
+++ b/src/ios/TransparentCoverVerticalAnimator.m
@@ -27,7 +27,7 @@
         [UIView animateWithDuration:[self transitionDuration:transitionContext] animations:^{
             //fromViewController.view.tintAdjustmentMode = UIViewTintAdjustmentModeDimmed;
             toViewController.view.frame = endRect;
-            fromViewController.view.alpha = 0.5f;
+            fromViewController.view.alpha = 0.8f;
         } completion:^(BOOL finished) {
             [transitionContext completeTransition:YES];
         }];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -18,12 +18,13 @@ interface IDatePickerOptions {
   locale?: string;
   okText?: string;
   cancelText?: string;
+  clearText?: string;
   android?: {
     theme?: number; // Theme_DeviceDefault_Dialog
     calendar?: boolean;
     is24HourView?: boolean;
   };
-  success: (newDate: Date) => void;
+  success: (newDate?: Date) => void;
   cancel?: () => void;
   error: (err: Error) => void;
 }
@@ -44,11 +45,11 @@ interface DateTimePicker {
    * NOTE: The successCallback and errorCallback respectively will be ignored if the success or error callback is provided on the options argument.
    *
    * @param {IDatePickerOptions} options
-   * @param {(newDate: Date) => void} successCb
+   * @param {(newDate?: Date) => void} successCb
    * @param {(err: Error) => void} errorCb
    * @memberof DateTimePicker
    */
-  show(options: IDatePickerOptions, successCb: (newDate: Date) => void, errorCb: (err: Error) => void): void;
+  show(options: IDatePickerOptions, successCb: (newDate?: Date) => void, errorCb: (err: Error) => void): void;
 
   /**
    * Hide the date/time picker.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -19,6 +19,7 @@ interface IDatePickerOptions {
   okText?: string;
   cancelText?: string;
   clearText?: string;
+  titleText?: string;
   android?: {
     theme?: number; // Theme_DeviceDefault_Dialog
     calendar?: boolean;

--- a/types/typings-test.ts
+++ b/types/typings-test.ts
@@ -16,6 +16,7 @@ const optionsFull: IDatePickerOptions = {
   locale: 'en_GB',
   okText: 'Select',
   cancelText: 'Cancel',
+  clearText: 'Clear',
   android: {
     theme: 5, // Theme_DeviceDefault_Dialog
     calendar: false,

--- a/types/typings-test.ts
+++ b/types/typings-test.ts
@@ -17,6 +17,7 @@ const optionsFull: IDatePickerOptions = {
   okText: 'Select',
   cancelText: 'Cancel',
   clearText: 'Clear',
+  titleText: 'Picker title',
   android: {
     theme: 5, // Theme_DeviceDefault_Dialog
     calendar: false,

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -48,6 +48,7 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 		locale: "EN",
 		okText: null,
 		cancelText: null,
+		clearText: null,
 		android: {
 			theme: undefined,	// If omitted/undefined, default theme will be used.
 			calendar: false
@@ -87,6 +88,9 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 				} else if (utils.isNumber(result.ticks)) {
 					var resultDate = new Date(result.ticks);
 					utils.isFunction(settings.success) && settings.success.apply(this, [ resultDate ]);
+				}
+				else {
+					utils.isFunction(settings.success) && settings.success.apply(this, []);
 				}
 				return;
 			}

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -49,6 +49,7 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 		okText: null,
 		cancelText: null,
 		clearText: null,
+		titleText: null,
 		android: {
 			theme: undefined,	// If omitted/undefined, default theme will be used.
 			calendar: false

--- a/www/datetimepicker.js
+++ b/www/datetimepicker.js
@@ -45,7 +45,7 @@ DateTimePicker.prototype.show = function(options, successCallback, errorCallback
 		allowOldDates: null,
 		allowFutureDates: null,
 		minuteInterval: 1,
-		locale: "EN",
+		locale: null,
 		okText: null,
 		cancelText: null,
 		clearText: null,


### PR DESCRIPTION
### New

- iOS: added iOS 13 dark mode support ([#35](https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker/issues/35)).
- Android/iOS: add `clearText` property which - when specified - adds a button with intend to clear the current date. When the user taps this button, the `success` callback will be called with an `undefined` date and the picker is closed. Backwards compatible due to having to opt-in.
- Android/iOS: add `titleText` property which when specified sets the dialog title.

### Changes

- Android/iOS: removed default button texts. Instead, now OS defaults are used.
- iOS: removed default locale 'EN'. Instead, the user locale is used.
- iOS: refactored to use `UINavigationBar` and Auto Layout.
- iOS: made modal background slightly less opaque.

### Fixes

- iOS: ([#33](https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker/issues/33)) fix picker sometimes showing 1 januari when using `minuteInterval` > 1 and `allowOldDates` or `allowFutureDates` is set to `false`.