### PR TITLE
v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 Changelog for [skwas-cordova-plugin-datetimepicker](./README.md).
 
+## 2.1.1
+
+### Fixes
+
+- Android: build error 'local variable callbackContext is accessed from within inner class; needs to be declared final' ([#37](https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker/issues/37))
+
 ## 2.1.0
 
 ### New

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "skwas-cordova-plugin-datetimepicker",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.0",
+  "version": "2.1.1",
   "name": "skwas-cordova-plugin-datetimepicker",
   "cordova_name": "DateTime picker",
   "description": "Cordova DateTime picker plugin",

--- a/plugin.xml
+++ b/plugin.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="skwas-cordova-plugin-datetimepicker"
-    version="2.1.0">
+    version="2.1.1">
     <name>DateTime picker</name>
     <description>Cordova DateTime picker plugin</description>
     <license>MIT</license>

--- a/src/android/DateTimePicker.java
+++ b/src/android/DateTimePicker.java
@@ -293,7 +293,7 @@ public class DateTimePicker extends CordovaPlugin {
 		dialog.show();
 	}
 
-	private void setClearButton(AlertDialog dialog, CallbackContext callbackContext, String clearText) {
+	private void setClearButton(final AlertDialog dialog, final CallbackContext callbackContext, final String clearText) {
 		if (TextUtils.isEmpty(clearText)) {
 			return;
 		}
@@ -317,7 +317,7 @@ public class DateTimePicker extends CordovaPlugin {
 	 * @param calendar        The calendar with the new date and/or time.
 	 * @param callbackContext The callback context.
 	 */
-	private synchronized void onCalendarSet(Calendar calendar, CallbackContext callbackContext) {
+	private synchronized void onCalendarSet(final Calendar calendar, final CallbackContext callbackContext) {
 		Date selectedDate = calendar.getTime();
 
 		try {


### PR DESCRIPTION
### Fixes

- Android: build error 'local variable callbackContext is accessed from within inner class; needs to be declared final' ([#37](https://github.com/skwasjer/skwas-cordova-plugin-datetimepicker/issues/37))
