### PR TITLE
Prefer wheels style on iOS 14.

### DIFF
--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -96,6 +96,11 @@
 
 - (void)configureDatePicker:(NSMutableDictionary *)optionsOrNil datePicker:(UIDatePicker *)datePicker {
     
+    // Prefer wheels style on iOS 14.
+    if (@available(iOS 13.4, *)) {
+        datePicker.preferredDatePickerStyle = UIDatePickerStyleWheels;
+    }
+    
     // Mode (must be set first, otherwise minuteInterval > 1 acts wonky).
     NSString *mode = [optionsOrNil objectForKey:@"mode"];
     if ([mode isEqualToString:@"date"]) {


### PR DESCRIPTION
First of all, thank you for this great plugin, really saved my day! :tada:

The default date picker style on iOS 14 is pretty much unusable and looks bad:
<img src="https://user-images.githubusercontent.com/5544859/94030608-4f0bac00-fdbe-11ea-9af0-3581fb55e556.png" height="200"/>

When clicking on it, it opens a popup with a calendar to enter the date, with the keyboard... :scream: Also it doesn't support the minutes interval:
<img src="https://user-images.githubusercontent.com/5544859/94030702-69de2080-fdbe-11ea-9090-bc01e475211e.png" height="200"/>

To get a calendar, you don't really need this library but can just use a `<input type="datetime"/>` instead, so this PR changes it to prefer the nice wheels style (just as in iOS 13):
<img src="https://user-images.githubusercontent.com/5544859/94030777-7e221d80-fdbe-11ea-845c-80b9e16f5484.png" height="200"/>

In the future, adding an option to customize the style from JavaScript might be a good solution. If you want, I can look into that.