### PR TITLE
Hide keyboard input when clicking on ios current datetime entry

### DIFF
--- a/src/ios/DateTimePicker.h
+++ b/src/ios/DateTimePicker.h
@@ -11,6 +11,7 @@ enum DTPDateBounds {
     
 - (void)show:(CDVInvokedUrlCommand*)command;
 - (void)hide:(CDVInvokedUrlCommand*)command;
+- (void)handleDatePickerTap;
 
 @property (strong) ModalPickerViewController* modalPicker;
 

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -99,6 +99,7 @@
     // Prefer wheels style on iOS 14.
     if (@available(iOS 13.4, *)) {
         datePicker.preferredDatePickerStyle = UIDatePickerStyleWheels;
+        [datePicker addTarget:self action:@selector(handleDatePickerTap:) forControlEvents:UIControlEventEditingDidBegin];
     }
     
     // Mode (must be set first, otherwise minuteInterval > 1 acts wonky).
@@ -172,6 +173,10 @@
 
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:result];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:_callbackId];
+}
+
+- (void)handleDatePickerTap:(id)sender{
+  [sender resignFirstResponder];
 }
 
 @end

--- a/src/ios/DateTimePicker.m
+++ b/src/ios/DateTimePicker.m
@@ -76,6 +76,10 @@
     picker.modalPresentationStyle = UIModalPresentationCustom;
     picker.transitioningDelegate = self;
 
+    if (@available(iOS 13.4, *)) {
+        [picker.datePicker addTarget:self action:@selector(handleDatePickerTap:) forControlEvents:UIControlEventEditingDidBegin];
+    }
+
     picker.doneHandler = ^(id sender) {
         ModalPickerViewController *modelPicker = (ModalPickerViewController *)sender;
         if (modelPicker == nil) {
@@ -99,7 +103,6 @@
     // Prefer wheels style on iOS 14.
     if (@available(iOS 13.4, *)) {
         datePicker.preferredDatePickerStyle = UIDatePickerStyleWheels;
-        [datePicker addTarget:self action:@selector(handleDatePickerTap:) forControlEvents:UIControlEventEditingDidBegin];
     }
     
     // Mode (must be set first, otherwise minuteInterval > 1 acts wonky).


### PR DESCRIPTION
When using the wheel mode (iOS 14+), if the user clicks on the currently selected datetime it opens a keyboard over the datetime input.

This behaviour looks weird as we don't know what this number input is for as it overlays with the plugin UI.

This PR disables this behaviour by adding a `.editingDidBegin` event handler which calls `resignFirstResponder` on the datetime ui control.

See below video for demo of the initial issue.

https://user-images.githubusercontent.com/15731884/174600055-4e1f6559-2258-444e-a585-5e94560c1f5a.mov


